### PR TITLE
Added option to directly specify collate directory

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -101,6 +101,9 @@ all collation jobs are single CPU jobs and are not parallelised.
    Ignore these files during collation. This can either be a single filename or
    a list of filenames. Only FMS models (MOM, GOLD) support this setting.
 
+``collate_flags``
+   Specify the flags passed to the collation program.
+   Only FMS models (MOM, GOLD) support this setting.
 
 Model
 -----

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -163,3 +163,11 @@ For most jobs, collation is called automatically. But if you need to manually
 collate the ``K``\ th run, type the following::
 
    payu collate -i K
+
+Alternatively you can directly specify a directory name::
+
+  payu collate -d dir_name
+
+This is useful when the data files have been moved out of the payu
+directory structure, or if you need to collate restart files, which is
+necessary when changing processor layout.

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -101,7 +101,7 @@ def get_model_type(model_type, config):
         sys.exit(-1)
 
 
-def set_env_vars(init_run=None, n_runs=None, lab_path=None):
+def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None):
     """Construct the environment variables used by payu for resubmissions."""
 
     payu_env_vars = {}
@@ -160,6 +160,9 @@ def set_env_vars(init_run=None, n_runs=None, lab_path=None):
 
     if lab_path:
         payu_env_vars['PAYU_LAB_PATH'] = lab_path
+
+    if dir_path:
+        payu_env_vars['PAYU_DIR_PATH'] = dir_path
 
     return payu_env_vars
 

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -245,9 +245,16 @@ class Experiment(object):
         self.stderr_fname = self.lab.model_type + '.err'
 
     def set_output_paths(self):
+
         # Local archive paths
-        output_dir = 'output{:03}'.format(self.counter)
-        self.output_path = os.path.join(self.archive_path, output_dir)
+
+        # Check to see if we've provided a hard coded path -- valid for collate
+        dir_path = os.environ.get('PAYU_DIR_PATH')
+        if dir_path is not None:
+            self.output_path = dir_path
+        else:
+            output_dir = 'output{:03}'.format(self.counter)
+            self.output_path = os.path.join(self.archive_path, output_dir)
 
         # TODO: check case counter == 0
         prior_output_dir = 'output{:03}'.format(self.counter - 1)

--- a/payu/subcommands/args.py
+++ b/payu/subcommands/args.py
@@ -69,3 +69,15 @@ hard_sweep = {
         'help':     'Delete archived output',
     }
 }
+
+# Explicitly set output_path
+dir_path = {
+    'flags': ('--directory', '--dir', '-d'),
+    'parameters': {
+        'action':   'store',
+        'dest':     'dir_path',
+        'default':  None,
+        'help':     'The output directory, this will over-ride the \
+                     directory determined from current run number',
+    }
+}

--- a/payu/subcommands/collate_cmd.py
+++ b/payu/subcommands/collate_cmd.py
@@ -15,13 +15,13 @@ title = 'collate'
 parameters = {'description': 'Collate tiled output into single output files'}
 
 arguments = [args.model, args.config, args.initial, args.nruns,
-             args.laboratory]
+             args.laboratory, args.dir_path]
 
 
-def runcmd(model_type, config_path, init_run, n_runs, lab_path):
+def runcmd(model_type, config_path, init_run, n_runs, lab_path, dir_path):
 
     pbs_config = cli.get_config(config_path)
-    pbs_vars = cli.set_env_vars(init_run, n_runs, lab_path)
+    pbs_vars = cli.set_env_vars(init_run, n_runs, lab_path, dir_path)
 
     collate_queue = pbs_config.get('collate_queue', 'copyq')
     pbs_config['queue'] = collate_queue
@@ -73,7 +73,8 @@ def runscript():
     run_args = parser.parse_args()
 
     pbs_vars = cli.set_env_vars(run_args.init_run, run_args.n_runs,
-                                run_args.lab_path)
+                                run_args.lab_path, run_args.dir_path)
+
     for var in pbs_vars:
         os.environ[var] = str(pbs_vars[var])
 


### PR DESCRIPTION
Hey Marshall,

I had a crack at implementing the option to directly specify a collate directory. 

I did a few quick tests, and it seems to work from payu collate and payu-collate. 

I'm not sure if this is the way you would have done it, or if I might have broken something else. In any case, have a look, and tell me what you think.

It has another use I hadn't thought about: collating restarts for changing processor count/layout.

Cheers