### PR TITLE
Added parallel collation for fms and fixed a small bug in '-d' implementation

### DIFF
--- a/payu/cli.py
+++ b/payu/cli.py
@@ -159,10 +159,10 @@ def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None):
         payu_env_vars['PAYU_N_RUNS'] = n_runs
 
     if lab_path:
-        payu_env_vars['PAYU_LAB_PATH'] = lab_path
+        payu_env_vars['PAYU_LAB_PATH'] = os.path.normpath(lab_path)
 
     if dir_path:
-        payu_env_vars['PAYU_DIR_PATH'] = dir_path
+        payu_env_vars['PAYU_DIR_PATH'] = os.path.normpath(dir_path)
 
     return payu_env_vars
 

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -251,7 +251,7 @@ class Experiment(object):
         # Check to see if we've provided a hard coded path -- valid for collate
         dir_path = os.environ.get('PAYU_DIR_PATH')
         if dir_path is not None:
-            self.output_path = dir_path
+            self.output_path = os.path.normpath(dir_path)
         else:
             output_dir = 'output{:03}'.format(self.counter)
             self.output_path = os.path.join(self.archive_path, output_dir)

--- a/payu/subcommands/collate_cmd.py
+++ b/payu/subcommands/collate_cmd.py
@@ -26,11 +26,14 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path, dir_path):
     collate_queue = pbs_config.get('collate_queue', 'copyq')
     pbs_config['queue'] = collate_queue
 
-    # Collation jobs are (currently) serial
-    pbs_config['ncpus'] = 1
+    n_cpus_request = pbs_config.get('collate_ncpus', 1)
+    pbs_config['ncpus'] = n_cpus_request
 
     # Modify jobname
-    pbs_config['jobname'] = pbs_config['jobname'][:13] + '_c'
+    if 'jobname' in pbs_config:
+        pbs_config['jobname'] = pbs_config.get('jobname', default_job_name)[:13] + '_c'
+    else:
+        pbs_config['jobname'] = os.path.normpath(dir_path[:15])
 
     # Replace (or remove) walltime
     collate_walltime = pbs_config.get('collate_walltime')


### PR DESCRIPTION
Paul's collation jobs were taking a long time, he was saving at high temporal resolution and doing ensembles, and my high temporal resolution 0.1 deg sims were taking 12+ hours to collate, so this is a fix of sorts.

I think it would be better to submit multiple collate jobs, but that would have been a bigger change, so I settled for using multiprocessing to submit multiple jobs within one collate job.

This adds config option collate_ncpus, to specify the number of cpus to be requested for the collate PBS submission.

The drawback is that multiprocessor jobs can't be submitted to the copy queue on raijin, so normal or express must be specified. Care must be taken to also request enough memory for multiple collate jobs to run simultaneously.

There was a bug in the '-d' directory path implementation, that it didn't work at all when invoked in a directory that wasn't the laboratory, which sort of defeats the purpose. In any case a minimal config.yaml must be supplied so that payu knows the model type. If the job name can't be determined payu-collate falls back to the name the PBS job after the directory path being collated. I had an issue with a trailing slash on the PBS job name interacting poorly with PBS. I sprinkled a few os.path.normpath calls around, but in the end the only one that matters is in collate_cmd.py. I left the others in as I didn't think they could do any harm, and might be beneficial.