### PR TITLE
Made payu-collate respect collate_ncpus from config. Fixed bug introduced in last commit: referencing unknown variable

### DIFF
--- a/payu/models/fms.py
+++ b/payu/models/fms.py
@@ -15,14 +15,23 @@ import os
 import resource as res
 import shlex
 import subprocess as sp
-import multiprocessing
-from multiprocessing.dummy import Pool
-
-def runcmd(cmd, cwd):
-    return sp.call(shlex.split(cmd), cwd=cwd)
+# Use multiprocessing dummy (threads) as collate jobs run in own process
+import multiprocessing.dummy as multiprocessing
 
 # Local
 from payu.models.model import Model
+
+def runcmd(cmd, cwd):
+    # This is run in a thread, so the GIL of python makes it sensible to
+    # capture the output from each process and print it out at the end so
+    # it doesn't get scrambled when collates are run in parallel
+    result = True
+    try:
+        output = sp.check_output(shlex.split(cmd), cwd=cwd, stderr=sp.STDOUT)
+    except:
+        result = False
+    print output
+    return result
 
 class Fms(Model):
 
@@ -93,9 +102,11 @@ class Fms(Model):
 
             mnc_tiles[t_base].append(t_fname)
 
-        # We use a multiprocessing dummy pool (so just threads) as the collate
-        # jobs are run in their own process
-        pool = Pool(processes=multiprocessing.cpu_count())
+
+        # If this is run interactively NCPUS is set in collate_cmd, otherwise
+        # the cpu_count will return the number of CPUs assigned to the PBS job
+        count = int(os.environ.get('NCPUS',multiprocessing.cpu_count()))
+        pool = multiprocessing.Pool(processes=count)
 
         # Collate each tileset into a single file
         for nc_fname in mnc_tiles:

--- a/payu/models/fms.py
+++ b/payu/models/fms.py
@@ -21,7 +21,7 @@ import multiprocessing.dummy as multiprocessing
 # Local
 from payu.models.model import Model
 
-def runcmd(cmd, cwd):
+def cmdthread(cmd, cwd):
     # This is run in a thread, so the GIL of python makes it sensible to
     # capture the output from each process and print it out at the end so
     # it doesn't get scrambled when collates are run in parallel
@@ -30,7 +30,7 @@ def runcmd(cmd, cwd):
         output = sp.check_output(shlex.split(cmd), cwd=cwd, stderr=sp.STDOUT)
     except:
         result = False
-    print output
+    print(output)
     return result
 
 class Fms(Model):
@@ -120,7 +120,7 @@ class Fms(Model):
 
             cmd = '{} {} {} {}'.format(mppnc_path, collate_flags, nc_fname, ' '.join(mnc_tiles[nc_fname]))
             print cmd
-            pool.apply_async(runcmd, args=(cmd,self.output_path))
+            pool.apply_async(cmdthread, args=(cmd,self.output_path))
 
         pool.close()
         pool.join()

--- a/payu/subcommands/collate_cmd.py
+++ b/payu/subcommands/collate_cmd.py
@@ -31,7 +31,7 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path, dir_path):
 
     # Modify jobname
     if 'jobname' in pbs_config:
-        pbs_config['jobname'] = pbs_config.get('jobname', default_job_name)[:13] + '_c'
+        pbs_config['jobname'] = pbs_config['jobname'][:13] + '_c'
     else:
         pbs_config['jobname'] = os.path.normpath(dir_path[:15])
 
@@ -84,6 +84,11 @@ def runscript():
     lab = Laboratory(run_args.model_type, run_args.config_path,
                      run_args.lab_path)
     expt = Experiment(lab)
+
+    if 'PAYU_CURRENT_RUN' not in os.environ:
+        # Not a PBS batch job: set ncpus in environment
+        if 'collate_ncpus' in expt.config:
+            os.environ['NCPUS'] = str(expt.config['collate_ncpus'])
 
     expt.collate()
     if expt.postscript:

--- a/payu/subcommands/collate_cmd.py
+++ b/payu/subcommands/collate_cmd.py
@@ -85,7 +85,7 @@ def runscript():
                      run_args.lab_path)
     expt = Experiment(lab)
 
-    if 'PAYU_CURRENT_RUN' not in os.environ:
+    if 'PBS_NCPUS' not in os.environ:
         # Not a PBS batch job: set ncpus in environment
         if 'collate_ncpus' in expt.config:
             os.environ['NCPUS'] = str(expt.config['collate_ncpus'])


### PR DESCRIPTION
Previous version didn't work when submitted as a batch job because of a dumb error I introduced. Should have checked that.

The only substantial revision is to make fms.collate respect the collate_ncpus setting from config. This wasn't the case in the previous version. That config was only used in the batch version, which sets up the number of CPUs for the job and fms.collate just grabbed the number of CPUs from the environment.

So now payu-collate does (collate_cmd.py) does a (slightly bodgy) test to see if we're in a PBS environment (not strictly necessary I guess ... ) and then sets an environment variable to pass this information on to fms.collate.

Marshall, maybe you'd prefer not to do that bodgy test and just set the environment variable? I tried looking in the run command to find an analogous example, but couldn't see anything. If there is a standard/usual/better way of doing this I'm happy to change it.