### PR TITLE
Changed mpi socket/node mapping arguments to mpirun: old arguments no…

### DIFF
--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -446,9 +446,9 @@ class Experiment(object):
             # TODO: New Open MPI format?
             if model_npernode:
                 if model_npernode % 2 == 0:
-                    npernode_flag = '-npersocket {}'.format(model_npernode / 2)
+                    npernode_flag = '-map-by ppr:{}:socket'.format(model_npernode / 2)
                 else:
-                    npernode_flag = '-npernode {}'.format(model_npernode)
+                    npernode_flag = '-map-by ppr:{}:node'.format(model_npernode)
 
                 if self.config.get('scalasca', False):
                     npernode_flag = '\"{}\"'.format(npernode_flag)

--- a/payu/reversion.py
+++ b/payu/reversion.py
@@ -45,7 +45,7 @@ def repython(version, script_path):
 
         # First unload all python (and supporting) modules
         python_modules = [m for m in os.environ['LOADEDMODULES'].split(':')
-                          if m.startswith('python')]
+                          if m.startswith('python/')]
 
         for mod in python_modules:
             envmod.module('unload', mod)


### PR DESCRIPTION
… longer work. Added trailing slash to python module detection, to protect pythonlib/ modules

To address issue:

https://github.com/marshallward/payu/issues/50