### PR TITLE
Added explicit exception catching to cmdthread in fms.py

### DIFF
--- a/payu/models/fms.py
+++ b/payu/models/fms.py
@@ -29,7 +29,8 @@ def cmdthread(cmd, cwd):
     result = True
     try:
         output = sp.check_output(shlex.split(cmd), cwd=cwd, stderr=sp.STDOUT)
-    except:
+    except CalledProcessError as e:
+        print("{} failed, returned errorcode {}".format(e.cmd,e.returncode)
         result = False
     print(output)
     return result


### PR DESCRIPTION
Addressing https://github.com/marshallward/payu/issues/73

I'm not entirely sure why I let this just go through, I guess we're sanguine about a collation failing, and will want to still collate other files if possible. It is up to the user to check and maybe alter resources for the collation step.