### PR TITLE
Add option for multiple runs per PBS submit (runspersub)

### DIFF
--- a/payu/envmod.py
+++ b/payu/envmod.py
@@ -59,8 +59,9 @@ def setup(basepath=DEFAULT_BASEPATH):
     # the problematic variable here.  But a more general solution would be nice
     # someday.
 
-    bash_func_module = os.environ['BASH_FUNC_module()']
-    os.environ['BASH_FUNC_module()'] = bash_func_module.replace('\n', ';')
+    if 'BASH_FUNC_module()' in os.environ:
+        bash_func_module = os.environ['BASH_FUNC_module()']
+        os.environ['BASH_FUNC_module()'] = bash_func_module.replace('\n', ';')
 
 
 def module(command, *args):

--- a/payu/models/access.py
+++ b/payu/models/access.py
@@ -85,6 +85,12 @@ class Access(Model):
 
                     prior_cpl_fpath = os.path.join(model.prior_restart_path,
                                                    cpl_fname)
+                    # With later versions this file exists in the prior restart path,
+                    # but this was not always the case, so check, and if not there use
+                    # prior output path
+                    if not os.path.exists(prior_cpl_fpath):
+                        prior_cpl_fpath = os.path.join(model.prior_output_path, cpl_fname)
+
                     prior_cpl_nml = f90nml.read(prior_cpl_fpath)
                     cpl_nml_grp = prior_cpl_nml[cpl_group]
 

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -148,6 +148,14 @@ class Cice(Model):
 
             prior_nml_path = os.path.join(self.prior_restart_path,
                                           self.ice_nml_fname)
+
+            # With later versions this file exists in the prior restart path,
+            # but this was not always the case, so check, and if not there use
+            # prior output path
+            if not os.path.exists(prior_nml_path):
+                prior_nml_path = os.path.join(self.prior_output_path,
+                                            self.ice_nml_fname)
+
             prior_setup_nml = f90nml.read(prior_nml_path)['setup_nml']
 
             # The total time in seconds since the beginning of the experiment

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -119,25 +119,26 @@ def runscript():
                      run_args.lab_path)
     expt = Experiment(lab)
 
-    n_runs_per_submit = expt.config.get('runspersub',1)
-
     expt.setup()
 
-    while n_runs_per_submit > 0:
+    n_runs_per_submit = expt.config.get('runspersub',1)
+
+    subrun = 1
+
+    while subrun <= n_runs_per_submit and expt.n_runs > 0:
  
-        print("nruns: {} nruns_per_submit: {}".format(expt.n_runs, n_runs_per_submit))
-        n_runs_per_submit -= 1
+        print("nruns: {} nruns_per_submit: {} subrun: {}".format(expt.n_runs, n_runs_per_submit, subrun))
 
         expt.setup()
         expt.run()
         expt.archive()
 
-        if expt.n_runs <= 0:
-            break
-        else:
-            # Need to manually increment the run counter
+        # Need to manually increment the run counter if still looping
+        if n_runs_per_submit > 1 and subrun < n_runs_per_submit:
             expt.counter += 1
             expt.set_output_paths()
+
+        subrun += 1
 
     if expt.n_runs > 0:
         expt.resubmit()

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -119,10 +119,25 @@ def runscript():
                      run_args.lab_path)
     expt = Experiment(lab)
 
+    n_runs_per_submit = expt.config.get('runspersub',1)
+
     expt.setup()
 
-    expt.run()
-    expt.archive()
+    while n_runs_per_submit > 0:
+ 
+        print("nruns: {} nruns_per_submit: {}".format(expt.n_runs, n_runs_per_submit))
+        n_runs_per_submit -= 1
+
+        expt.setup()
+        expt.run()
+        expt.archive()
+
+        if expt.n_runs <= 0:
+            break
+        else:
+            # Need to manually increment the run counter
+            expt.counter += 1
+            expt.set_output_paths()
 
     if expt.n_runs > 0:
         expt.resubmit()


### PR DESCRIPTION
Added a config option `nrunspersub` to run multiple model runs for each PBS submission which addresses https://github.com/marshallward/payu/issues/84

Implemented this as a parameter in `config.yaml` as it affects the choice of PBS parameters, i.e. `walltime`.

This option respects the existing `-n` method of specifying multiple model runs, as `n_runs` is decremented as normal.

I did try specifying the number of resubmits as a command line option, but I don't think it works as well.