### PR TITLE
Fix issue #99, number of ice restart files growing with time

### DIFF
--- a/payu/models/cice5.py
+++ b/payu/models/cice5.py
@@ -83,10 +83,11 @@ class Cice5(Cice):
 
         # Delete the old restart file (keep the one in ice.restart_file)
         for f in self.get_prior_restart_files():
-            if 'iced.' in f:
-                assert f != res_name
+            if f.startswith('iced.'):
+                if f == res_name:
+                    continue
                 os.remove(os.path.join(self.restart_path, f))
-                break
+
 
     def get_prior_restart_files(self):
         if self.prior_restart_path is not None:


### PR DESCRIPTION
This is a fix for https://github.com/marshallward/payu/issues/99

The number of iced restarts grows with time because they aren't all properly deleted. I think the previous logic assumed only one restart needed to be deleted. In the case where more than one restart was created the number of restarts would grow.

I have tested with a 1 deg ACCESS-OM model and this is the listing of restarts after 4 resubmissions

```bash
ls  -1 archive/restart27[2-7]/ice/iced.*
archive/restart272/ice/iced.0541-04-01-00000.nc
archive/restart273/ice/iced.0541-05-01-00000.nc
archive/restart274/ice/iced.0541-06-01-00000.nc
archive/restart275/ice/iced.0541-07-01-00000.nc
```

So one restart for every restart directory. I had a feeling that `CICE` could use multiple restarts, but I can't recall why I think this.

Any comments @nicjhan?