### PR TITLE
ACCESS-OM2 driver support separate from ACCESS driver. #101

### DIFF
--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -108,17 +108,15 @@ class Experiment(object):
 
         submodels = self.config.get('submodels', [])
 
-        if not submodels:
+        solo_model = self.config.get('model')
+        if not solo_model:
+            sys.exit('payu: error: Unknown model configuration.')
 
-            solo_model = self.config.get('model')
-            if not solo_model:
-                sys.exit('payu: error: Unknown model configuration.')
+        submodel_config = {f: self.config[f] for f in model_fields \
+                           if f in self.config}
+        submodel_config['name'] = solo_model
 
-            submodel_config = {f: self.config[f] for f in model_fields
-                               if f in self.config}
-            submodel_config['name'] = solo_model
-
-            submodels = [submodel_config]
+        submodels.append(submodel_config)
 
         for m_config in submodels:
             ModelType = model_index[m_config['model']]
@@ -130,6 +128,7 @@ class Experiment(object):
             model_config = {f: self.config[f] for f in model_fields
                             if f in self.config}
             self.model = ModelType(self, self.model_name, model_config)
+            self.model.top_level_model = True
         else:
             self.model = None
 
@@ -342,6 +341,7 @@ class Experiment(object):
             cmd = 'lfs setstripe -c 8 -s 8m {}'.format(self.work_path)
             sp.check_call(shlex.split(cmd))
 
+        # FIXME: Why does this cause warnings for ACCESS-OM2?
         make_symlink(self.work_path, self.work_sym_path)
 
         for model in self.models:

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -341,7 +341,6 @@ class Experiment(object):
             cmd = 'lfs setstripe -c 8 -s 8m {}'.format(self.work_path)
             sp.check_call(shlex.split(cmd))
 
-        # FIXME: Why does this cause warnings for ACCESS-OM2?
         make_symlink(self.work_path, self.work_sym_path)
 
         for model in self.models:

--- a/payu/models/__init__.py
+++ b/payu/models/__init__.py
@@ -1,4 +1,5 @@
 from payu.models.access import Access
+from payu.models.accessom2 import AccessOm2
 from payu.models.cice import Cice
 from payu.models.cice5 import Cice5
 from payu.models.gold import Gold
@@ -11,16 +12,18 @@ from payu.models.oasis import Oasis
 from payu.models.um import UnifiedModel
 from payu.models.ww3 import WW3
 from payu.models.qgcm import Qgcm
+from payu.models.yatm import Yatm
 
 from payu.models.model import Model
 
 index = {
     'access':     Access,
-    'access-om2': Access,
+    'access-om2': AccessOm2,
     'cice':     Cice,
     'cice5':    Cice5,
     'gold':     Gold,
     'matm':     Matm,
+    'yatm':     Yatm,
     'mitgcm':   Mitgcm,
     'mom':      Mom,
     'nemo':     Nemo,

--- a/payu/models/access.py
+++ b/payu/models/access.py
@@ -48,6 +48,8 @@ class Access(Model):
                 model.get_ptr_restart_dir = model.get_access_ptr_restart_dir
 
     def setup(self):
+        if not self.top_level_model:
+            return
 
         cpl_keys = {'cice': ('input_ice.nml', 'coupling_nml', 'runtime0'),
                     'matm': ('input_atm.nml', 'coupling', 'truntime0')}
@@ -173,6 +175,8 @@ class Access(Model):
                     f.write(s)
 
     def archive(self):
+        if not self.top_level_model:
+            return
 
         for model in self.expt.models:
             if model.model_type == 'cice':
@@ -206,3 +210,12 @@ class Access(Model):
             o2i_src = os.path.join(mom.work_path, 'o2i.nc')
             o2i_dst = os.path.join(cice5.restart_path, 'o2i.nc')
             shutil.copy2(o2i_src, o2i_dst)
+
+    def set_model_pathnames(self):
+        pass
+
+    def set_input_paths(self):
+        pass
+
+    def set_model_output_paths(self):
+        pass

--- a/payu/models/accessom2.py
+++ b/payu/models/accessom2.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+"""
+The payu interface for the ACCESSOM2 coupled model
+-------------------------------------------------------------------------------
+Contact: Marshall Ward <marshall.ward@anu.edu.au>
+-------------------------------------------------------------------------------
+Distributed as part of Payu, Copyright 2011 Marshall Ward
+Licensed under the Apache License, Version 2.0
+http://www.apache.org/licenses/LICENSE-2.0
+"""
+from __future__ import print_function
+
+import os
+import shutil
+
+from payu.models.model import Model
+
+class AccessOm2(Model):
+
+    def __init__(self, expt, name, config):
+        super(AccessOm2, self).__init__(expt, name, config)
+
+        self.model_type = 'access-om2'
+        self.config_files = ['accessom2.nml', 'namcouple']
+        self.top_level_model = True
+
+    def setup(self):
+        # HACK: only call setup if this is called as a submodule
+        if not self.top_level_model:
+            super(AccessOm2, self).setup()
+
+    def set_model_pathnames(self):
+        super(AccessOm2, self).set_model_pathnames()
+
+        # HACK: overwrite what super has done with these.
+        self.work_path = self.expt.work_path
+        self.control_path = self.expt.control_path
+
+        self.work_input_path = self.work_path
+        self.work_restart_path = self.work_path
+        self.work_output_path = self.work_path
+        self.work_init_path = self.work_path
+
+        self.work_input_path = os.path.join(self.work_path, 'INPUT')
+        self.work_restart_path = os.path.join(self.work_path, 'RESTART')
+
+    def set_input_paths(self):
+        super(AccessOm2, self).set_input_paths()
+
+        # HACK: overwrite what super has done with this.
+        input_dirs = self.expt.config.get('input')
+
+    def set_model_output_paths(self):
+        super(AccessOm2, self).set_model_output_paths()
+
+        # HACK: overwrite what super has done with these.
+        self.output_path = self.expt.output_path
+        self.restart_path = self.expt.restart_path
+
+        self.prior_output_path = self.expt.prior_output_path
+        self.prior_restart_path = self.expt.prior_restart_path
+
+    def archive(self):
+
+        # HACK: only called when this is a submodule
+        if not self.top_level_model:
+            shutil.rmtree(self.work_input_path)
+            for f in os.listdir(self.work_restart_path):
+                shutil.move(os.path.join(self.work_restart_path, f), self.restart_path)
+            os.rmdir(self.work_restart_path)

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -30,6 +30,7 @@ class Model(object):
         self.expt = expt
         self.name = model_name
         self.config = model_config
+        self.top_level_model = False
 
         # Model details
         self.model_type = None

--- a/payu/models/yatm.py
+++ b/payu/models/yatm.py
@@ -1,0 +1,43 @@
+# coding: utf-8
+"""payu.models.yatm
+   ================
+
+   Driver interface to the YATM model.
+
+   :copyright: Copyright 2011 Marshall Ward, see AUTHORS for details
+   :license: Apache License, Version 2.0, see LICENSE for details
+"""
+
+# Standard Library
+import os
+import shutil
+
+# Local
+from payu.models.model import Model
+from payu.fsops import mkdir_p
+
+class Yatm(Model):
+
+    def __init__(self, expt, name, config):
+        super(Yatm, self).__init__(expt, name, config)
+
+        self.model_type = 'yatm'
+        self.config_files = ['atm.nml', 'forcing.json']
+
+    def setup(self):
+        super(Yatm, self).setup()
+
+        # Make log dir
+        mkdir_p(os.path.join(self.work_path, 'log'))
+
+    def set_model_pathnames(self):
+        super(Yatm, self).set_model_pathnames()
+
+        self.work_input_path = os.path.join(self.work_path, 'INPUT')
+
+    def archive(self):
+
+        # Create an empty restart directory
+        mkdir_p(self.restart_path)
+
+        shutil.rmtree(self.work_input_path)


### PR DESCRIPTION
The coupled model config now looks like the below, which I think is an improvement. There is a bit of hackery to deal with the fact that the top level model is treated differently in payu to the submodels. Going forward perhaps we could remove this distinction? I think it was probably me who did this in the first place to get ACCESS working ... not sure it was the right approach. 

Notice no more oasis model, also access-om2 model has some common files. 

```
model: access-om2
input: common_1deg_jra55
submodels:
    - name: atmosphere
      model: yatm
      exe: yatm_2362fd31.exe
      input: yatm
      ncpus: 1

    - name: ocean
      model: mom
      exe: fms_ACCESS-OM_3f58ddc6.x
      input: mom_1deg
      ncpus: 216

    - name: ice
      model: cice5
      exe: cice_auscom_360x300_24p_a6bce947.exe
      input: cice_1deg
      ncpus: 24
```