### PR TITLE
Add file tracking to payu

### DIFF
--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -381,7 +381,7 @@ class Experiment(object):
         self.manifest.make_links()
 
         # Copy manifests to work directory so they archived on completion
-        self.manifest.copy_manifests(self.work_path)
+        self.manifest.copy_manifests(os.path.join(self.work_path,'manifests'))
 
         # Call the macro-model setup
         if len(self.models) > 1:

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -457,7 +457,7 @@ class Experiment(object):
         for model in self.models:
 
             # Skip models without executables (e.g. couplers)
-            if not model.local_exec_path:
+            if not model.exec_path_local:
                 continue
 
             mpi_config = self.config.get('mpi', {})
@@ -466,7 +466,7 @@ class Experiment(object):
             # Update MPI library module (if not explicitly set)
             # TODO: Check for MPI library mismatch across multiple binaries
             if mpi_module is None:
-                mpi_module = envmod.lib_update(model.local_exec_path, 'libmpi.so')
+                mpi_module = envmod.lib_update(model.exec_path_local, 'libmpi.so')
 
             model_prog = []
 

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -26,7 +26,7 @@ from payu.fsops import mkdir_p, make_symlink, read_config
 from payu.models import index as model_index
 import payu.profilers
 from payu.runlog import Runlog
-from payu import Manifest
+from payu.manifest import Manifest
 
 # Environment module support on vayu
 # TODO: To be removed
@@ -371,48 +371,14 @@ class Experiment(object):
 
         make_symlink(self.work_path, self.work_sym_path)
 
+        # Set up all file manifests
+        self.manifest.setup()
+
         for model in self.models:
             model.setup()
 
-        # Use manifest to make symbolic links to executables in the work directory
-        if self.have_exe_manifest:
-            self.input_manifest.make_links()
-
-        # Use manifest to make symbolic links to inputs in the work directory
-        if self.have_input_manifest:
-            self.input_manifest.make_links()
-
-        # Use manifest to make symbolic links to restarts in the work directory
-        if self.have_restart_manifest:
-            self.restart_manifest.make_links()
-
-        if not self.reproduce:
-            # Add full hash to all existing files. Don't force, will only add if they don't already exist
-            print("Add full hashes to input manifest")
-            self.input_manifest.add(hashfn=full_hashes)
-            print("Writing input manifest")
-            self.input_manifest.dump()
-            # Add full hash to all existing files. Don't force, will only add if they don't already exist
-            print("Add full hashes to restart manifest")
-            self.restart_manifest.add(hashfn=full_hashes)
-            print("Writing restart manifest")
-            self.restart_manifest.dump()
-
-        if not self.reproduce_exe:
-            # Add full hash to all existing files. Don't force, will only add if they don't already exist
-            print("Add full hashes to exe manifest")
-            self.exe_manifest.add(hashfn=full_hashes)
-            print("Writing exe manifest")
-            self.exe_manifest.dump()
-
-        print("Checking input manifest")
-        self.input_manifest.check_fast(reproduce=self.reproduce)
-
-        print("Checking restart manifest")
-        self.restart_manifest.check_fast(reproduce=self.reproduce)
-
-        print("Checking exe manifest")
-        self.exe_manifest.check_fast(reproduce=self.reproduce_exe)
+        # Use manifest to populate work directory
+        self.manifest.make_links()
 
         # Call the macro-model setup
         if len(self.models) > 1:

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -377,15 +377,15 @@ class Experiment(object):
         for model in self.models:
             model.setup()
 
+        # Call the macro-model setup
+        if len(self.models) > 1:
+            self.model.setup()
+
         # Use manifest to populate work directory
         self.manifest.make_links()
 
         # Copy manifests to work directory so they archived on completion
         self.manifest.copy_manifests(os.path.join(self.work_path,'manifests'))
-
-        # Call the macro-model setup
-        if len(self.models) > 1:
-            self.model.setup()
 
         setup_script = self.userscripts.get('setup')
         if setup_script:

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -380,6 +380,9 @@ class Experiment(object):
         # Use manifest to populate work directory
         self.manifest.make_links()
 
+        # Copy manifests to work directory so they archived on completion
+        self.manifest.copy_manifests(self.work_path)
+
         # Call the macro-model setup
         if len(self.models) > 1:
             self.model.setup()

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -11,6 +11,7 @@
 # Standard library
 import errno
 import os
+import subprocess
 
 # Extensions
 import yaml
@@ -119,3 +120,9 @@ def patch_lustre_path(f_path):
             f_path = './' + f_path
 
     return f_path
+
+def get_git_revision_hash():
+    return subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
+
+def get_git_revision_short_hash():
+    return subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -10,7 +10,7 @@
 
 # Standard library
 import errno
-import os
+import sys, os
 import subprocess
 
 # Extensions
@@ -122,7 +122,20 @@ def patch_lustre_path(f_path):
     return f_path
 
 def get_git_revision_hash():
-    return subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
+    try:
+        hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'])
+        import pdb; pdb.set_trace()
+        if sys.version_info.major==3:
+          hash.decode('ascii')
+        return hash.strip() 
+    except subprocess.CalledProcessError:
+        return None
 
 def get_git_revision_short_hash():
-    return subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
+    try:
+        hash = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'])
+        if sys.version_info.major==3:
+          hash.decode('ascii')
+        return hash.strip() 
+    except subprocess.CalledProcessError:
+        return None

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -124,7 +124,6 @@ def patch_lustre_path(f_path):
 def get_git_revision_hash():
     try:
         hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'])
-        import pdb; pdb.set_trace()
         if sys.version_info.major==3:
           hash.decode('ascii')
         return hash.strip() 

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -138,7 +138,8 @@ def get_commit_id(filepath):
     cmd = shlex.split("git log -n 1 --pretty=format:%H -- ")
     cmd.append(filepath)
     try:
-        hash = subprocess.check_output(cmd)
+        with open(os.devnull, 'w') as devnull:
+            hash = subprocess.check_output(cmd, stderr=devnull)
         if sys.version_info.major==3:
           hash.decode('ascii')
         return hash.strip() 
@@ -154,7 +155,8 @@ def get_git_revision_hash(short=False):
         cmd.insert(-1,'--short')
 
     try:
-        hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'])
+        with open(os.devnull, 'w') as devnull:
+            hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'], stderr=devnull)
         if sys.version_info.major==3:
           hash.decode('ascii')
         return hash.strip() 
@@ -165,5 +167,10 @@ def is_ancestor(id1, id2):
     """
     Return True if git commit id1 is a ancestor of git commit id2
     """
-    revs = subprocess.check_output(['git', 'rev-list', id2])
-    return id1 in revs
+    try:
+        with open(os.devnull, 'w') as devnull:
+            revs = subprocess.check_output(['git', 'rev-list', id2], stderr=devnull)
+    except:
+        return None
+    else:
+        return id1 in revs

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -50,9 +50,6 @@ def read_config(config_fname=None):
             config = {}
         else:
             raise
-    else:
-        # Store the git commit id for later use
-        config['_git_commit_id'] = get_commit_id(config_fname)
   
     collate_config = config.pop('collate', {})
 

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -120,6 +120,18 @@ class PayuManifest(YaManifest):
                 shutil.copy(self.fullpath(filepath), filepath)
             else:
                 make_symlink(self.fullpath(filepath), filepath)
+    
+    def check_correct(self):
+        hashvals = {}
+        if not self.check(hashvals=hashvals):
+            print("Manifest {} is not correct, run cannot reproduce, aborting ...".format(self.path))
+            print("Incorrect hashes:")
+            for path, hashdict in hashvals.items():
+                print("    {}:".format(path))
+                for hash, val in hashdict.items():
+                    print("        {}: {} != {}".format(hash,val,self.data[path]['hashes'].get(hash,None)))
+            exit(1)
+
 
 class Manifest(object):
     """
@@ -238,12 +250,8 @@ class Manifest(object):
 
         if self.reproduce:
             print("Checking input and restart manifests")
-            if not self.input_manifest.check():
-                print("Input manifest is not correct, run cannot reproduce, aborting ...")
-                exit(1)
-            if not self.restart_manifest.check():
-                print("Restart manifest is not correct, run cannot reproduce, aborting ...")
-                exit(1)
+            self.input_manifest.check_correct()
+            self.restart_manifest.check_correct():
         else:
             # Add full hash to all existing files. Don't force, will only add if they don't already exist
             print("Adding hashes to input and restart manifests")
@@ -255,9 +263,7 @@ class Manifest(object):
 
         if self.reproduce_exe:
             print("Checking exe manifest")
-            if not self.exe_manifest.check():
-                print("Exe manifest is not correct, reproduce_exe is True, run cannot reproduce, aborting ...")
-                exit(1)
+            self.exe_manifest.check_correct()
         else:
             # Add full hash to all existing files. Don't force, will only add if they don't already exist
             print("Add full hashes to exe manifest")

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -1,7 +1,8 @@
 """payu.manifest
    ===============
 
-   Interface to a manifest file
+   Provides an manifest class to store manifest data, which uses a 
+   subclassed yamanifest PayuManifest class
 
    :copyright: Copyright 2011 Marshall Ward, see AUTHORS for details.
    :license: Apache License, Version 2.0, see LICENSE for details.
@@ -19,7 +20,7 @@ from yamanifest.manifest import Manifest as YaManifest
 import yamanifest as ym
 from copy import deepcopy
 
-import os,sys
+import os, sys
 
 
 # fast_hashes = ['nchash','binhash']
@@ -104,11 +105,16 @@ class PayuManifest(YaManifest):
                 make_symlink(self.fullpath(filepath), filepath)
 
 class Manifest(object):
+    """
+    A Manifest class which stores all manifests for file tracking and 
+    methods to operate on them 
+    """
 
-    def __init__(self, expt):
+    def __init__(self, expt, reproduce):
 
         # Inherit experiment configuration
         self.expt = expt
+        self.reproduce = reproduce
 
         # Manifest control configuration
         self.manifest_config = self.expt.config.get('manifest', {})
@@ -127,6 +133,8 @@ class Manifest(object):
         self.input_manifest = PayuManifest(self.manifest_config.get('input', 'mf_input.yaml'))
         self.restart_manifest = PayuManifest(self.manifest_config.get('restart', 'mf_restart.yaml'))
         self.exe_manifest = PayuManifest(self.manifest_config.get('exe', 'mf_exe.yaml'))
+
+    def setup(self):
 
         # Check if manifest files exist
         self.have_input_manifest = os.path.exists(self.input_manifest.path) and not self.manifest_config.get('overwrite',False)

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -42,7 +42,6 @@ class PayuManifest(YaManifest):
         if ignore is not None:
             self.ignore = ignore
 
-        self.header['git_commit_id'] = None
         self.needsync = False
 
     def check_fast(self, reproduce=False, **args):
@@ -89,13 +88,6 @@ class PayuManifest(YaManifest):
 
                 # Flag need to update version on disk
                 self.needsync = True
-    def git_id(self, id=None):
-        """
-        Return and optionally set the git commit id (hash) in the header of the manifest file
-        """
-        if id is not None:
-            self.header['git_commit_id'] = id
-        return self.header['git_commit_id']
             
     def dump(self):
         """
@@ -241,15 +233,6 @@ class Manifest(object):
 
             if len(self.manifests['input']) > 0:
                 self.have_manifest['input'] = True
-
-            if self.have_manifest['input']:
-                # Warn if config has changed since input manifest was created.
-                # TODO: check input field in the YaML file has changed since
-                ret = is_ancestor(self.expt.config['git_commit_id'], self.manifests['input'].git_id())
-                # is_ancestor will return None if there is no git repo, so allow for this case
-                if ret is not None and not ret:
-                    print("\nWARNING! Config file has been altered since input manifest was generated.") 
-                    print("If input paths have changed delete manifests/input.yaml to rescan input directories\n") 
 
         if os.path.exists(self.manifests['exe'].path):
             # Read manifest

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -13,7 +13,7 @@ from __future__ import print_function, absolute_import
 
 # Local
 from payu import envmod
-from payu.fsops import make_symlink
+from payu.fsops import make_symlink, get_git_revision_hash
 
 # External
 from yamanifest.manifest import Manifest as YaManifest
@@ -84,6 +84,13 @@ class PayuManifest(YaManifest):
                 print("Writing {}".format(self.path))
                 self.dump()
             
+    def dump(self):
+        """
+        Add git hash to header before dumping the file
+        """
+        self.header['githash'] = get_git_revision_hash()
+        super(PayuManifest, self).dump()
+
     def add_filepath(self, filepath, fullpath, copy=False):
         """
         Bespoke function to add filepath & fullpath to manifest

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -134,7 +134,8 @@ class Manifest(object):
         self.restart_manifest = PayuManifest(self.manifest_config.get('restart', 'mf_restart.yaml'))
         self.exe_manifest = PayuManifest(self.manifest_config.get('exe', 'mf_exe.yaml'))
 
-    def setup(self):
+    # Does it make sense to split this off into a different setup routine when other stuff is defined?
+    # def setup(self):
 
         # Check if manifest files exist
         self.have_input_manifest = os.path.exists(self.input_manifest.path) and not self.manifest_config.get('overwrite',False)

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -21,6 +21,7 @@ import yamanifest as ym
 from copy import deepcopy
 
 import os, sys
+import shutil
 
 
 # fast_hashes = ['nchash','binhash']

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -1,0 +1,214 @@
+"""payu.manifest
+   ===============
+
+   Interface to a manifest file
+
+   :copyright: Copyright 2011 Marshall Ward, see AUTHORS for details.
+   :license: Apache License, Version 2.0, see LICENSE for details.
+"""
+
+# Python3 preparation
+from __future__ import print_function, absolute_import
+
+# Local
+from payu import envmod
+from payu.fsops import make_symlink
+
+# External
+from yamanifest.manifest import Manifest as YaManifest
+import yamanifest as ym
+from copy import deepcopy
+
+import os,sys
+
+
+# fast_hashes = ['nchash','binhash']
+fast_hashes = ['binhash']
+full_hashes = ['md5']
+
+class PayuManifest(YaManifest):
+    """
+    A manifest object sub-classed from yamanifest object with some payu specific
+    additions and enhancements
+    """
+
+    def __init__(self, path, hashes=None, **kwargs):
+        super(PayuManifest, self).__init__(path, hashes, **kwargs)
+
+    def check_fast(self, reproduce=False, **args):
+        """
+        Check hash value for all filepaths using a fast hash function and fall back to slower
+        full hash functions if fast hashes fail to agree
+        """
+        hashvals = {}
+        if not self.check_file(filepaths=self.data.keys(),hashvals=hashvals,hashfn=fast_hashes,shortcircuit=True,**args):
+            # Run a fast check, if we have failures, deal with them here
+            for filepath in hashvals:
+                print("Check failed for {} {}".format(filepath,hashvals[filepath]))
+                tmphash = {}
+                if self.check_file(filepaths=filepath,hashfn=full_hashes,hashvals=tmphash,shortcircuit=False,**args):
+                    # File is still ok, so replace fast hashes
+                    print("Full hashes ({}) checked ok".format(full_hashes))
+                    print("Updating fast hashes for {} in {}".format(filepath,self.path))
+                    self.add_fast(filepath,force=True)
+                else:
+                    # File has changed, update hashes unless reproducing run
+                    if not reproduce:
+                        print("Updating entry for {} in {}".format(filepath,self.path))
+                        self.add_fast(filepath,force=True)
+                        self.add(filepath,hashfn=full_hashes,force=True)
+                    else:
+                        sys.stderr.write("Run cannot reproduce: manifest {} is not correct\n".format(self.path))
+                        for fn in full_hashes:
+                            sys.stderr.write("Hash {}: manifest: {} file: {}\n".format(fn,self.data[filepath]['hashes'][fn],tmphash[fn]))
+                        sys.exit(1)
+
+            # Write updates to version on disk
+            self.dump()
+            
+
+    def add_fast(self, filepath, hashfn=fast_hashes, force=False):
+        """
+        Bespoke function to add filepaths but set shortcircuit to True, which means
+        only the first calculatable hash will be stored. In this way only one "fast"
+        hashing function need be called for each filepath
+        """
+        self.add(filepath, hashfn, force, shortcircuit=True)
+        
+    def copy_file(self, filepath):
+        """
+        Returns flag which says to copy rather than link a file
+        """
+        copy_file = False
+        try:
+            copy_file = self.data[filepath]['copy']
+        except KeyError:
+            return False
+        return copy_file
+
+    def make_links(self):
+        """
+        Payu integration function for creating symlinks in work directories which point
+        back to the original file
+        """
+        print("Making links from manifest: {}".format(self.path))
+        for filepath in self:
+            # print("Linking {}".format(filepath))
+            # Don't try and link to itself, which happens when there is a real
+            # file in the work directory, and not a symbolic link
+            # if not os.path.realpath(filepath) == self.fullpath(filepath):
+            #     make_symlink(self.fullpath(filepath), filepath)
+            if self.copy_file(filepath):
+                shutil.copy(self.fullpath(filepath), filepath)
+            else:
+                make_symlink(self.fullpath(filepath), filepath)
+
+class Manifest(object):
+
+    def __init__(self, expt):
+
+        # Inherit experiment configuration
+        self.expt = expt
+
+        # Manifest control configuration
+        self.manifest_config = self.expt.config.get('manifest', {})
+        
+        self.have_restart_manifest = False
+
+        # If the run sets reproduce, default to reproduce executables. Allow user
+        # to specify not to reproduce executables (might not be feasible if
+        # executables don't match platform, or desirable if bugs existed in old exe)
+        self.reproduce_exe = self.reproduce and self.manifest_config.get('reproduce_exe',True)
+
+        # Not currently supporting specifying hash functions
+        # self.hash_functions = manifest_config.get('hashfns', ['nchash','binhash','md5'])
+
+        # Intialise manifests. Can specify the path in config
+        self.input_manifest = PayuManifest(self.manifest_config.get('input', 'mf_input.yaml'))
+        self.restart_manifest = PayuManifest(self.manifest_config.get('restart', 'mf_restart.yaml'))
+        self.exe_manifest = PayuManifest(self.manifest_config.get('exe', 'mf_exe.yaml'))
+
+        # Check if manifest files exist
+        self.have_input_manifest = os.path.exists(self.input_manifest.path) and not self.manifest_config.get('overwrite',False)
+        self.have_restart_manifest = os.path.exists(self.restart_manifest.path)
+        self.have_exe_manifest = os.path.exists(self.exe_manifest.path)
+
+        if self.reproduce:
+            # MUST have input and restart manifests to be able to reproduce a run
+            assert(self.have_input_manifest)
+            assert(self.have_restart_manifest)
+            if self.reproduce_exe:
+                assert(self.have_exe_manifest)
+        else:
+            # Only use a restart manifest when reproducing a run, otherwise always generare a new one
+            self.have_restart_manifest = False
+
+        if self.have_input_manifest:
+            # Read manifest
+            print("Loading input manifest: {}".format(self.input_manifest.path))
+            self.input_manifest.load()
+
+            if len(self.input_manifest) == 0:
+                if self.reproduce:
+                    raise ValueError('Input manifest is empty, but reproduce is true')
+                # if manifest is empty revert flag to ensure input directories are used
+                self.have_input_manifest = False
+
+        if self.have_exe_manifest and self.reproduce_exe:
+            # Read manifest
+            print("Loading exe manifest: {}".format(self.exe_manifest.path))
+            self.exe_manifest.load()
+
+            if len(self.exe_manifest) == 0:
+                if self.reproduce:
+                    raise ValueError('Exe manifest is empty, but reproduce and reproduce_exe is true')
+                # if manifest is empty revert flag to ensure input directories are used
+                self.have_exe_manifest = False
+        else:
+            self.have_exe_manifest = False
+
+        if self.reproduce:
+            # Read restart manifest
+            print("Loading restart manifest: {}".format(self.restart_manifest.path))
+            self.restart_manifest.load()
+
+            # Restart manifest must be populated for a reproducible run
+            assert(len(self.input_manifest) > 0)
+
+            for model in self.expt.models:
+                model.have_restart_manifest = True
+
+            # If the run counter is zero inspect the restart manifest for an appropriate
+            # value
+            for filepath in self.restart_manifest:
+                head = os.path.dirname(self.restart_manifest.fullpath(filepath))
+                # Inspect each element of the fullpath looking for restartxxx style
+                # directories. Exit 
+                while true:
+                    head, tail = os.path.split(head)
+                    if tail.startswith('restart'):
+                        try:
+                            n = int(tail.lstrip('restart'))
+                        except ValueError:
+                            pass
+                        else:
+                            self.counter = n + 1
+                            break
+                            
+                # Short circuit as soon as restart dir found
+                if self.expt.counter == 0: break
+                            
+        else:
+
+            # Generate a restart manifest
+            for model in self.expt.models:
+                if model.prior_restart_path is not None:
+                    # Try and find a manifest file in the restart dir
+                    restart_mf = PayuManifest.find_manifest(model.prior_restart_path)
+                    if restart_mf is not None:
+                        print("Loading restart manifest: {}".format(os.path.join(model.prior_restart_path,restart_mf.path)))
+                        self.restart_manifest.update(restart_mf,newpath=os.path.join(model.work_init_path_local))
+                        # Have two flags, one per model, the other controls if there is a call
+                        # to make_links in setup()
+                        model.have_restart_manifest = True
+                        # self.have_restart_manifest = True

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -89,13 +89,6 @@ class PayuManifest(YaManifest):
                 # Flag need to update version on disk
                 self.needsync = True
             
-    def dump(self):
-        """
-        Add git hash to header before dumping the file
-        """
-        self.git_id(id=get_git_revision_hash())
-        super(PayuManifest, self).dump()
-
     def add_filepath(self, filepath, fullpath, copy=False):
         """
         Bespoke function to add filepath & fullpath to manifest
@@ -207,6 +200,8 @@ class Manifest(object):
 
         # Make sure the manifests directory exists
         mkpath(os.path.dirname(self.manifests['exe'].path))
+
+        self.scaninputs = self.manifest_config.get('scaninputs',True)
 
     def __iter__(self):
         """

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -196,34 +196,41 @@ class Manifest(object):
             if len(self.restart_manifest) > 0:
                 self.have_restart_manifest = True
             else:
-                raise ValueError("Reproduce is True but restart manifest is empty")
+                print("Restart manifest cannot be empty if reproduce is True")
+                exit(1)
+
             if not self.have_input_manifest:
-                raise ValueError("Reproduce is True but input manifest is empty")
+                print("Input manifest cannot be empty if reproduce is True")
+                exit(1)
+
             if self.reproduce_exe and not self.have_exe_manifest:
-                raise ValueError("Reproduce is True but executable manifest is empty and reproduce_exe not set to False")
+                print("Executable manifest cannot empty if reproduce and reproduce_exe are True")
+                exit(1)
 
             for model in self.expt.models:
                 model.have_restart_manifest = True
 
-            # If the run counter is zero inspect the restart manifest for an appropriate
-            # value
-            for filepath in self.restart_manifest:
-                head = os.path.dirname(self.restart_manifest.fullpath(filepath))
-                # Inspect each element of the fullpath looking for restartxxx style
-                # directories. Exit 
-                while True:
-                    head, tail = os.path.split(head)
-                    if tail.startswith('restart'):
-                        try:
-                            n = int(tail.lstrip('restart'))
-                        except ValueError:
-                            pass
-                        else:
-                            self.counter = n + 1
-                            break
-                            
-                # Short circuit as soon as restart dir found
-                if self.expt.counter == 0: break
+
+            # Inspect the restart manifest for an appropriate value of # experiment 
+            # counter if not specified on the command line (and this env var set)
+            if not os.environ.get('PAYU_CURRENT_RUN'):
+                for filepath in self.restart_manifest:
+                    head = os.path.dirname(self.restart_manifest.fullpath(filepath))
+                    # Inspect each element of the fullpath looking for restartxxx style
+                    # directories. Exit 
+                    while True:
+                        head, tail = os.path.split(head)
+                        if tail.startswith('restart'):
+                            try:
+                                n = int(tail.lstrip('restart'))
+                            except ValueError:
+                                pass
+                            else:
+                                self.expt.counter = n + 1
+                                break
+                                
+                    # Short circuit as soon as restart dir found
+                    if self.expt.counter == 0: break 
                             
         else:
 

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -136,6 +136,12 @@ class PayuManifest(YaManifest):
             else:
                 make_symlink(self.fullpath(filepath), filepath)
 
+    def copy(self, path):
+        """
+        Copy myself to another location
+        """
+        shutil.copy(self.path, path)
+
 class Manifest(object):
     """
     A Manifest class which stores all manifests for file tracking and 
@@ -267,3 +273,9 @@ class Manifest(object):
         else:
             print("Creating restart manifest")
         self.restart_manifest.check_fast(reproduce=self.reproduce)
+
+    def copy_manifests(self, path):
+
+        self.exe_manifest.copy(path)
+        self.input_manifest.copy(path)
+        self.restart_manifest.copy(path)

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -251,7 +251,7 @@ class Manifest(object):
         if self.reproduce:
             print("Checking input and restart manifests")
             self.input_manifest.check_correct()
-            self.restart_manifest.check_correct():
+            self.restart_manifest.check_correct()
         else:
             # Add full hash to all existing files. Don't force, will only add if they don't already exist
             print("Adding hashes to input and restart manifests")

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -284,19 +284,6 @@ class Manifest(object):
 
             self.have_manifest['restart'] = False
 
-            # # Generate a restart manifest
-            # for model in self.expt.models:
-            #     if model.prior_restart_path is not None:
-            #         # Try and find a manifest file in the restart dir
-            #         restart_mf = PayuManifest.find_manifest(model.prior_restart_path)
-            #         if restart_mf is not None:
-            #             print("Loading restart manifest: {}".format(os.path.join(model.prior_restart_path,restart_mf.path)))
-            #             self.restart_manifest.update(restart_mf,newpath=os.path.join(model.work_init_path_local))
-            #             # Have two flags, one per model, the other controls if there is a call
-            #             # to make_links in setup()
-            #             model.have_restart_manifest = True
-            #             # self.have_restart_manifest = True
-
     def make_links(self):
 
         print("Making links from manifests")

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -43,6 +43,12 @@ class Model(object):
         self.exec_path = None
         self.exec_name = None
         self.codebase_path = None
+        self.work_path_local = None
+        self.work_input_path_local = None
+        self.work_restart_path_local = None
+        self.work_init_path_local = None
+        self.exec_path_local = None
+
         self.build_exec_path = None
         self.build_path = None
 
@@ -77,10 +83,17 @@ class Model(object):
         self.exec_prefix = self.config.get('exe_prefix', '')
         self.exec_name = self.config.get('exe', self.default_exec)
         if self.exec_name:
+            # By default os.path.join will not prepend the lab bin_path
+            # to an absolute path
             self.exec_path = os.path.join(self.expt.lab.bin_path,
                                           self.exec_name)
         else:
             self.exec_path = None
+
+        if self.exec_path:
+            # Make exec_name consistent for models with fully qualified path.
+            # In all cases it will just be the name of the executable without a path
+            self.exec_name = os.path.basename(self.exec_path)
 
     def set_local_pathnames(self):
 
@@ -95,11 +108,10 @@ class Model(object):
                   os.path.relpath(self.work_restart_path,self.expt.work_path)))
         self.work_init_path_local = os.path.normpath(os.path.join('work',
                  os.path.relpath(self.work_init_path,self.expt.work_path)))
-        if self.exec_name:
-            # Local path in work directory (symlinked to full path and
-            # added to manifest)
-            self.local_exec_path = os.path.join(self.work_path_local,
-                                          self.exec_name)
+        if self.exec_path:
+            # Local path in work directory 
+            self.exec_path_local = os.path.join(self.work_path_local,
+                                          os.path.basename(self.exec_path))
 
     def set_input_paths(self):
 
@@ -203,7 +215,7 @@ class Model(object):
         # Make symlink to executable in work directory
         if self.exec_path: 
             # Add to exe manifest 
-            self.expt.manifest.exe_manifest.add_filepath(self.local_exec_path,self.exec_path)
+            self.expt.manifest.exe_manifest.add_filepath(self.exec_path_local,self.exec_path)
 
         timestep = self.config.get('timestep')
         if timestep:

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -200,9 +200,9 @@ class Model(object):
                 f_link = os.path.join(self.work_init_path_local, f_name)
                 self.expt.manifest.add_filepath('restart',f_link,f_orig,self.copy_inputs)
 
-        # Don't add input files to manifest if we already have a populated
-        # input manifest
-        if not self.expt.manifest.have_manifest['input']:
+        # Add input files to manifest if we don't already have a populated
+        # input manifest, or we specify scan_inputs is True (default)
+        if not self.expt.manifest.have_manifest['input'] or self.expt.manifest.scaninputs:
             # Add files to manifest
             for input_path in self.input_paths:
                 input_files = os.listdir(input_path)

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -214,7 +214,7 @@ class Model(object):
 
         # Make symlink to executable in work directory
         if self.exec_path: 
-            # Add to exe manifest 
+            # Add to exe manifest (this is always done so any change in exe path will be picked up)
             self.expt.manifest.exe_manifest.add_filepath(self.exec_path_local,self.exec_path)
 
         timestep = self.config.get('timestep')

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -193,16 +193,16 @@ class Model(object):
                     raise
 
         # Add restart files from prior run to restart manifest
-        if not self.expt.manifest.have_restart_manifest and self.prior_restart_path:
+        if not self.expt.manifest.have_manifest['restart'] and self.prior_restart_path:
             restart_files = self.get_prior_restart_files()
             for f_name in restart_files:
                 f_orig = os.path.join(self.prior_restart_path, f_name)
                 f_link = os.path.join(self.work_init_path_local, f_name)
-                self.expt.manifest.restart_manifest.add_filepath(f_link,f_orig,self.copy_inputs)
+                self.expt.manifest.add_filepath('restart',f_link,f_orig,self.copy_inputs)
 
         # Don't add input files to manifest if we already have a populated
         # input manifest
-        if not self.expt.manifest.have_input_manifest:
+        if not self.expt.manifest.have_manifest['input']:
             # Add files to manifest
             for input_path in self.input_paths:
                 input_files = os.listdir(input_path)
@@ -211,12 +211,12 @@ class Model(object):
                     f_link = os.path.join(self.work_input_path_local,f_name)
                     # Do not use input file if it is in RESTART
                     if not os.path.exists(f_link):
-                        self.expt.manifest.input_manifest.add_filepath(f_link,f_orig,self.copy_inputs)
+                        self.expt.manifest.add_filepath('input',f_link,f_orig,self.copy_inputs)
 
         # Make symlink to executable in work directory
         if self.exec_path: 
             # Add to exe manifest (this is always done so any change in exe path will be picked up)
-            self.expt.manifest.exe_manifest.add_filepath(self.exec_path_local,self.exec_path)
+            self.expt.manifest.add_filepath('exe',self.exec_path_local,self.exec_path)
 
         timestep = self.config.get('timestep')
         if timestep:

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -167,7 +167,8 @@ class Model(object):
                                                        self.name)
 
     def get_prior_restart_files(self):
-        return os.listdir(self.prior_restart_path)
+        return [f for f in os.listdir(self.prior_restart_path) 
+                if os.path.isfile(os.path.join(self.prior_restart_path, f))]
 
     def setup(self):
 

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -207,7 +207,7 @@ class Model(object):
                 input_files = os.listdir(input_path)
                 for f_name in input_files:
                     f_input = os.path.join(input_path, f_name)
-                    f_work_input = os.path.join(self.work_init_path_local,f_name)
+                    f_work_input = os.path.join(self.work_input_path_local,f_name)
                     # Do not use input file if it is in RESTART
                     if not os.path.exists(f_work_input):
                         self.expt.manifest.input_manifest.add_filepath(f_work_input,f_input,self.copy_inputs)

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -179,29 +179,31 @@ class Model(object):
                 else:
                     raise
 
-        # Link restart files from prior run
-        if self.prior_restart_path:
+        # Add restart files from prior run to restart manifest
+        if not self.expt.manifest.have_restart_manifest and self.prior_restart_path:
             restart_files = self.get_prior_restart_files()
             for f_name in restart_files:
                 f_restart = os.path.join(self.prior_restart_path, f_name)
-                f_input = os.path.join(self.work_init_path, f_name)
-                if self.copy_restarts:
-                    shutil.copy(f_restart, f_input)
-                else:
-                    make_symlink(f_restart, f_input)
+                f_input = os.path.join(self.work_init_path_local, f_name)
+                self.expt.manifest.restart_manifest.add_filepath(f_input,f_restart,self.copy_inputs)
 
-        # Link input data
-        for input_path in self.input_paths:
-            input_files = os.listdir(input_path)
-            for f_name in input_files:
-                f_input = os.path.join(input_path, f_name)
-                f_work_input = os.path.join(self.work_input_path, f_name)
-                # Do not use input file if it is in RESTART
-                if not os.path.exists(f_work_input):
-                    if self.copy_inputs:
-                        shutil.copy(f_input, f_work_input)
-                    else:
-                        make_symlink(f_input, f_work_input)
+        # Don't add input files to manifest if we already have a populated
+        # input manifest
+        if not self.expt.manifest.have_input_manifest:
+            # Add files to manifest
+            for input_path in self.input_paths:
+                input_files = os.listdir(input_path)
+                for f_name in input_files:
+                    f_input = os.path.join(input_path, f_name)
+                    f_work_input = os.path.join(self.work_init_path_local,f_name)
+                    # Do not use input file if it is in RESTART
+                    if not os.path.exists(f_work_input):
+                        self.expt.manifest.input_manifest.add_filepath(f_work_input,f_input,self.copy_inputs)
+
+        # Make symlink to executable in work directory
+        if self.exec_path: 
+            # Add to exe manifest 
+            self.expt.manifest.exe_manifest.add_filepath(self.local_exec_path,self.exec_path)
 
         timestep = self.config.get('timestep')
         if timestep:

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -82,6 +82,25 @@ class Model(object):
         else:
             self.exec_path = None
 
+    def set_local_pathnames(self):
+
+        # This is the path relative to the control directory, required for manifests
+        # and must be called after set_model_pathnames to ensure it captures changes
+        # made in model subclasses which override set_model_pathnames
+        self.work_path_local = os.path.normpath(os.path.join('work',
+                os.path.relpath(self.work_path,self.expt.work_path)))
+        self.work_input_path_local = os.path.normpath(os.path.join('work',
+                 os.path.relpath(self.work_input_path,self.expt.work_path)))
+        self.work_restart_path_local = os.path.normpath(os.path.join('work',
+                  os.path.relpath(self.work_restart_path,self.expt.work_path)))
+        self.work_init_path_local = os.path.normpath(os.path.join('work',
+                 os.path.relpath(self.work_init_path,self.expt.work_path)))
+        if self.exec_name:
+            # Local path in work directory (symlinked to full path and
+            # added to manifest)
+            self.local_exec_path = os.path.join(self.work_path_local,
+                                          self.exec_name)
+
     def set_input_paths(self):
 
         if len(self.expt.models) == 1:

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -196,9 +196,9 @@ class Model(object):
         if not self.expt.manifest.have_restart_manifest and self.prior_restart_path:
             restart_files = self.get_prior_restart_files()
             for f_name in restart_files:
-                f_restart = os.path.join(self.prior_restart_path, f_name)
-                f_input = os.path.join(self.work_init_path_local, f_name)
-                self.expt.manifest.restart_manifest.add_filepath(f_input,f_restart,self.copy_inputs)
+                f_orig = os.path.join(self.prior_restart_path, f_name)
+                f_link = os.path.join(self.work_init_path_local, f_name)
+                self.expt.manifest.restart_manifest.add_filepath(f_link,f_orig,self.copy_inputs)
 
         # Don't add input files to manifest if we already have a populated
         # input manifest
@@ -207,11 +207,11 @@ class Model(object):
             for input_path in self.input_paths:
                 input_files = os.listdir(input_path)
                 for f_name in input_files:
-                    f_input = os.path.join(input_path, f_name)
-                    f_work_input = os.path.join(self.work_input_path_local,f_name)
+                    f_orig = os.path.join(input_path, f_name)
+                    f_link = os.path.join(self.work_input_path_local,f_name)
                     # Do not use input file if it is in RESTART
-                    if not os.path.exists(f_work_input):
-                        self.expt.manifest.input_manifest.add_filepath(f_work_input,f_input,self.copy_inputs)
+                    if not os.path.exists(f_link):
+                        self.expt.manifest.input_manifest.add_filepath(f_link,f_orig,self.copy_inputs)
 
         # Make symlink to executable in work directory
         if self.exec_path: 

--- a/payu/runlog.py
+++ b/payu/runlog.py
@@ -64,18 +64,16 @@ class Runlog(object):
             self.manifest.extend(os.path.join(model.control_path, f)
                                  for f in config_files)
 
-        # Add file manifests
-        self.manifest.append(self.expt.manifest.exe_manifest.path)
-        self.manifest.append(self.expt.manifest.input_manifest.path)
-        self.manifest.append(self.expt.manifest.restart_manifest.path)
+        # Add file manifests to runlog manifest
+        for mf in self.expt.manifest:
+            self.manifest.append(mf.path)
 
     def commit(self):
         f_null = open(os.devnull, 'w')
 
         # Check if a repository exists
         cmd = 'git rev-parse'
-        print(cmd)
-        rc = sp.call(shlex.split(cmd), stdout=f_null,
+        rc = sp.call(shlex.split(cmd), stdout=f_null, stderr=f_null,
                      cwd=self.expt.control_path)
         if rc:
             cmd = 'git init'

--- a/payu/runlog.py
+++ b/payu/runlog.py
@@ -64,6 +64,11 @@ class Runlog(object):
             self.manifest.extend(os.path.join(model.control_path, f)
                                  for f in config_files)
 
+        # Add file manifests
+        self.manifest.append(self.expt.manifest.exe_manifest.path)
+        self.manifest.append(self.expt.manifest.input_manifest.path)
+        self.manifest.append(self.expt.manifest.restart_manifest.path)
+
     def commit(self):
         f_null = open(os.devnull, 'w')
 

--- a/payu/subcommands/args.py
+++ b/payu/subcommands/args.py
@@ -91,3 +91,13 @@ dir_path = {
                      directory determined from current run number',
     }
 }
+
+# Specify a reproducible run
+reproduce = {
+    'flags': ('--reproduce', '--repro', '-r'),
+    'parameters': {
+        'action':   'store_true',
+        'dest':     'reproduce',
+        'help':     'Only run if manifests are correct',
+    }
+}

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -115,13 +115,10 @@ def runscript():
                      run_args.lab_path)
     expt = Experiment(lab)
 
-    expt.setup()
-
     n_runs_per_submit = expt.config.get('runspersub', 1)
-
     subrun = 1
 
-    while subrun <= n_runs_per_submit and expt.n_runs > 0:
+    while True:
 
         print('nruns: {0} nruns_per_submit: {1} subrun: {2}'
               ''.format(expt.n_runs, n_runs_per_submit, subrun))
@@ -130,6 +127,10 @@ def runscript():
         expt.run()
         expt.archive()
 
+        # Finished runs
+        if expt.n_runs == 0:
+            break
+
         # Need to manually increment the run counter if still looping
         if n_runs_per_submit > 1 and subrun < n_runs_per_submit:
             expt.counter += 1
@@ -137,7 +138,8 @@ def runscript():
             # Does not make sense to reproduce a multiple run. Take care of
             # this with argument processing?
             expt.reproduce = False
-            expt.manifest.setup()
+        else:
+            break
 
         subrun += 1
 

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -134,7 +134,10 @@ def runscript():
         if n_runs_per_submit > 1 and subrun < n_runs_per_submit:
             expt.counter += 1
             expt.set_output_paths()
-            expt.manifest.init_manifests()
+            # Does not make sense to reproduce a multiple run. Take care of
+            # this with argument processing?
+            expt.reproduce = False
+            expt.manifest.setup()
 
         subrun += 1
 

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -134,6 +134,7 @@ def runscript():
         if n_runs_per_submit > 1 and subrun < n_runs_per_submit:
             expt.counter += 1
             expt.set_output_paths()
+            expt.manifest.init_manifests()
 
         subrun += 1
 

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -12,10 +12,10 @@ title = 'run'
 parameters = {'description': 'Run the model experiment'}
 
 arguments = [args.model, args.config, args.initial, args.nruns,
-             args.laboratory]
+             args.laboratory, args.reproduce]
 
 
-def runcmd(model_type, config_path, init_run, n_runs, lab_path):
+def runcmd(model_type, config_path, init_run, n_runs, lab_path, reproduce):
 
     # Get job submission configuration
     pbs_config = fsops.read_config(config_path)
@@ -113,7 +113,7 @@ def runscript():
 
     lab = Laboratory(run_args.model_type, run_args.config_path,
                      run_args.lab_path)
-    expt = Experiment(lab)
+    expt = Experiment(lab, reproduce=run_args.reproduce)
 
     n_runs_per_submit = expt.config.get('runspersub', 1)
     subrun = 1

--- a/payu/subcommands/setup_cmd.py
+++ b/payu/subcommands/setup_cmd.py
@@ -7,13 +7,13 @@ import payu.subcommands.args as args
 title = 'setup'
 parameters = {'description': 'Setup model work directory for run'}
 
-arguments = [args.model, args.config, args.laboratory, args.force_archive]
+arguments = [args.model, args.config, args.laboratory, args.force_archive, args.reproduce]
 
 
-def runcmd(model_type, config_path, lab_path, force_archive):
+def runcmd(model_type, config_path, lab_path, force_archive, reproduce):
 
     lab = Laboratory(model_type, config_path, lab_path)
-    expt = Experiment(lab)
+    expt = Experiment(lab, reproduce=reproduce)
 
     expt.setup(force_archive=force_archive)
 

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,12 @@ setup(
         'f90nml',
         'PyYAML',
         'requests',
+        'yamanifest',
         'dateutil'
     ],
     install_requires=[
         'f90nml >= 0.16',
+        'yamanifest >= 0.3.4',
         'PyYAML',
         'requests[security]',
         'python-dateutil',


### PR DESCRIPTION
Add input/restart and executable file tracking to payu using the yamanifest module to create YaML based manifest files which are tracked by git. 

When they exist, manifest files are used to populate the input directories, restarts (when required) and links to the executables. This should allow for easier configuration sharing, as the experiment just needs to be cloned and can be run without further configuration changes.