### PR TITLE
Parse MITgcm config files to check they are correct namelists

### DIFF
--- a/payu/models/mitgcm.py
+++ b/payu/models/mitgcm.py
@@ -37,9 +37,23 @@ class Mitgcm(Model):
     def setup(self):
 
         # TODO: Find a better place to generate this list
-        self.config_files = [f for f in os.listdir(self.control_path)
+        files = [f for f in os.listdir(self.control_path)
                              if f.startswith('data')]
-        self.config_files.append('eedata')
+        files.append('eedata')
+
+        # Rudimentary check that matching files are namelists. Can only check if 
+        # namelist is empty. May excluded false positives, but these are # devoid 
+        # of useful information in that case
+        for fname in files:
+            nml_parser = f90nml.Parser()
+            nml_parser.comment_tokens += '#'
+
+            data_nml = nml_parser.read(fname)
+            if len(data_nml) > 0:
+                self.config_files.append(fname)
+            else:
+                print("Excluding {0} from list of configuration files: "\
+                      "assumed to be not a namelist file (or empty)".format(fname))
 
         # Generic model setup
         super(Mitgcm, self).setup()

--- a/payu/models/mitgcm.py
+++ b/payu/models/mitgcm.py
@@ -38,12 +38,12 @@ class Mitgcm(Model):
 
         # TODO: Find a better place to generate this list
         files = [f for f in os.listdir(self.control_path)
-                             if f.startswith('data')]
+                 if f.startswith('data')]
         files.append('eedata')
 
-        # Rudimentary check that matching files are namelists. Can only check if 
-        # namelist is empty. May excluded false positives, but these are # devoid 
-        # of useful information in that case
+        # Rudimentary check that matching files are namelists. Can only check
+        # if # namelist is empty. May excluded false positives, but these are
+        # devoid of useful information in that case
         for fname in files:
             nml_parser = f90nml.Parser()
             nml_parser.comment_tokens += '#'
@@ -52,8 +52,8 @@ class Mitgcm(Model):
             if len(data_nml) > 0:
                 self.config_files.append(fname)
             else:
-                print("Excluding {0} from list of configuration files: "\
-                      "assumed to be not a namelist file (or empty)".format(fname))
+                print("Excluding {0} from configuration files: assumed "
+                      "to be not a namelist file (or empty)".format(fname))
 
         # Generic model setup
         super(Mitgcm, self).setup()


### PR DESCRIPTION
Parse MITgcm config files to check they are correct namelists adding to list self.config_files.

Addresses https://github.com/marshallward/payu/issues/148.