### PR TITLE
Ensure restart file is always written when not reproducing.

### DIFF
--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -353,6 +353,7 @@ class Manifest(object):
             print("Checking restart manifest")
         else:
             print("Creating restart manifest")
+            self.manifests['restart'].needsync = True
         self.manifests['restart'].check_fast(reproduce=self.reproduce)
 
         # Write updates to version on disk


### PR DESCRIPTION
When starting from initial conditions from a control directory that has a restart manifest, e.g. after running `payu sweep --hard`, the `manifests/restart.yaml` file was not over-written.

This fixes this by setting the `needsync` flag.