### PR TITLE
Cleanup some errors in cleanup code introduced in recent commits

### DIFF
--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -639,12 +639,16 @@ class Experiment(object):
             # NOTE: This is PBS-specific
             job_id = get_job_id(short=False)
 
+            if job_id == '':
+                job_id = self.run_id[:6]
+
             for fname in self.output_fnames:
 
                 src = os.path.join(self.control_path, fname)
 
                 stem, suffix = os.path.splitext(fname)
-                dest = ".".join((stem, job_id, suffix))
+                dest = os.path.join(error_log_dir,
+                                    ".".join((stem, job_id)) + suffix)
 
                 print(src, dest)
 


### PR DESCRIPTION
Forgot to prepend error path to logs when run crashes.

Now use git commit hash to uniquely identify logs if PBS id not
available, e.g. using payu-run.