### PR TITLE
Added support for ability of cice5 to define separate input and restart directories.

### DIFF
--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -62,9 +62,9 @@ class Cice(Model):
         setup_nml = self.ice_in['setup_nml']
 
         res_path = os.path.normpath(setup_nml['restart_dir'])
-        input_dir = setup_nml.get('input_dir',None)
+        input_dir = setup_nml.get('input_dir', None)
 
-        if input_dir is None: 
+        if input_dir is None:
             # Default to reading and writing inputs/restarts in-place
             input_path = res_path
         else:
@@ -85,21 +85,25 @@ class Cice(Model):
         if not path == input_path:
             print('Grid file path in {nmlfile} ({gridpath}) does not match '
                   'input path ({inputpath})'.format(
-                    nmlfile=self.ice_nml_fname, 
-                    gridpath=path, 
-                    inputpath=input_path
-            ))
+                    nmlfile=self.ice_nml_fname,
+                    gridpath=path,
+                    inputpath=input_path))
             sys.exit(1)
 
         # Check paths are consistent in namelist
-        for var, nml in (('kmt_file', 'grid_nml'), ('pointer_file', 'setup_nml')):
+        for var, nml in (('kmt_file', 'grid_nml'),
+                         ('pointer_file', 'setup_nml')):
             tmp_path, _ = os.path.split(self.ice_in[nml].get(var))
             tmp_path = os.path.normpath(tmp_path)
             if not path == tmp_path:
-                print('Paths for {var} ({varpath}) and grid_file ({gridpath}) in {nmlfile} do not '
-                      'match'.format(var=var, varpath=tmp_path, gridpath=path, nmlfile=self.ice_nml_fname))
+                print('Paths for {var} ({varpath}) and grid_file '
+                      '({gridpath}) in {nmlfile} do not '
+                      'match'.format(var=var,
+                                     varpath=tmp_path,
+                                     gridpath=path,
+                                     nmlfile=self.ice_nml_fname))
                 sys.exit(1)
-            
+
         if not os.path.isabs(input_path):
             input_path = os.path.join(self.work_path, input_path)
         self.work_input_path = input_path
@@ -114,7 +118,6 @@ class Cice(Model):
         if not os.path.isabs(work_out_path):
             work_out_path = os.path.join(self.work_path, work_out_path)
         self.work_output_path = work_out_path
-
 
     def set_model_output_paths(self):
         super(Cice, self).set_model_output_paths()

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -141,7 +141,6 @@ class Cice(Model):
         return [sorted(restart_files)[-1]]
 
     def get_ptr_restart_dir(self):
-        # return self.ice_in['setup_nml']['restart_dir']
         return os.path.relpath(self.work_input_path, self.work_path)
 
     def get_access_ptr_restart_dir(self):

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -62,26 +62,41 @@ class Cice(Model):
         setup_nml = self.ice_in['setup_nml']
 
         res_path = os.path.normpath(setup_nml['restart_dir'])
+        input_path = setup_nml.get('input_dir',None)
+
+        if input_path is None: 
+            # Default to reading and writing inputs/restarts in-place
+            input_path = res_path
+
+            # Determine if there is a work input path from grid path
+            grid_nml = self.ice_in['grid_nml']
+            path, _ = os.path.split(grid_nml['grid_file'])
+            if path and not path == '.':
+                assert not os.path.isabs(path)
+                input_path = path
+
+            # Assert that kmt uses the same directory
+            kmt_input_path, _ = os.path.split(grid_nml['kmt_file'])
+            assert input_path == kmt_input_path
+
+        else:
+            input_path = os.path.normpath(input_path)
+            
+        if not os.path.isabs(input_path):
+            input_path = os.path.join(self.work_path, input_path)
+        self.work_input_path = input_path
+        self.work_init_path = self.work_input_path
+
         if not os.path.isabs(res_path):
             res_path = os.path.join(self.work_path, res_path)
-        self.work_init_path = res_path
         self.work_restart_path = res_path
 
         work_out_path = os.path.normpath(setup_nml['history_dir'])
+
         if not os.path.isabs(work_out_path):
             work_out_path = os.path.join(self.work_path, work_out_path)
         self.work_output_path = work_out_path
 
-        # Determine if there is a work input path
-        grid_nml = self.ice_in['grid_nml']
-        input_path, _ = os.path.split(grid_nml['grid_file'])
-        if input_path and not input_path == '.':
-            assert not os.path.isabs(input_path)
-            self.work_input_path = os.path.join(self.work_path, input_path)
-
-        # Assert that kmt uses the same directory
-        kmt_input_path, _ = os.path.split(grid_nml['kmt_file'])
-        assert input_path == kmt_input_path
 
     def set_model_output_paths(self):
         super(Cice, self).set_model_output_paths()
@@ -105,7 +120,8 @@ class Cice(Model):
         return [sorted(restart_files)[-1]]
 
     def get_ptr_restart_dir(self):
-        return self.ice_in['setup_nml']['restart_dir']
+        # return self.ice_in['setup_nml']['restart_dir']
+        return os.path.relpath(self.work_input_path, self.work_path)
 
     def get_access_ptr_restart_dir(self):
         # The ACCESS build of CICE assumes that restart_dir is 'RESTART'
@@ -145,7 +161,7 @@ class Cice(Model):
                 print('payu: error: No restart file available.')
                 sys.exit(errno.ENOENT)
 
-            res_ptr_path = os.path.join(self.work_init_path,
+            res_ptr_path = os.path.join(self.work_input_path,
                                         'ice.restart_file')
             with open(res_ptr_path, 'w') as res_ptr:
                 res_dir = self.get_ptr_restart_dir()

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -73,7 +73,7 @@ class Cice(Model):
         # Determine if there is a work input path from grid path
         grid_nml = self.ice_in['grid_nml']
         path, _ = os.path.split(grid_nml['grid_file'])
-        if path and not path == '.':
+        if path and not path == os.path.curdir:
             assert not os.path.isabs(path)
             path = os.path.normpath(path)
             # Get input_dir from grid_file path unless otherwise specified

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -82,7 +82,7 @@ class Cice(Model):
 
         # Check for consistency in input paths due to cice having the same
         # information in multiple locations
-        if not path == input_path:
+        if path != input_path:
             print('payu: error: '
                   'Grid file path in {nmlfile} ({gridpath}) does not match '
                   'input path ({inputpath})'.format(
@@ -92,19 +92,27 @@ class Cice(Model):
             sys.exit(1)
 
         # Check paths are consistent in namelist
-        for var, nml in (('kmt_file', 'grid_nml'),
-                         ('pointer_file', 'setup_nml')):
-            tmp_path, _ = os.path.split(self.ice_in[nml].get(var))
-            tmp_path = os.path.normpath(tmp_path)
-            if not path == tmp_path:
-                print('payu: error: '
-                      'Paths for {var} ({varpath}) and grid_file '
-                      '({gridpath}) in {nmlfile} do not '
-                      'match'.format(var=var,
-                                     varpath=tmp_path,
-                                     gridpath=path,
-                                     nmlfile=self.ice_nml_fname))
-                sys.exit(1)
+        tmp_path, _ = os.path.split(self.ice_in['grid_nml'].get('kmt_file'))
+        tmp_path = os.path.normpath(tmp_path)
+        if not path == tmp_path:
+            print('payu: error: '
+                  'Paths for kmt_file ({varpath}) and grid_file '
+                  '({gridpath}) in {nmlfile} do not '
+                  'match'.format(varpath=tmp_path,
+                                 gridpath=path,
+                                 nmlfile=self.ice_nml_fname))
+            sys.exit(1)
+
+        # Check paths are consistent in namelist
+        tmp_path, _ = os.path.split(self.ice_in['setup_nml'].get('pointer_file'))
+        tmp_path = os.path.normpath(tmp_path)
+        if not path == tmp_path:
+            print('payu: warning: '
+                  'Paths for pointer_file ({varpath}) and grid_file '
+                  '({gridpath}) in {nmlfile} do not '
+                  'match'.format(varpath=tmp_path,
+                                 gridpath=path,
+                                 nmlfile=self.ice_nml_fname))
 
         if not os.path.isabs(input_path):
             input_path = os.path.join(self.work_path, input_path)

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -83,7 +83,8 @@ class Cice(Model):
         # Check for consistency in input paths due to cice having the same
         # information in multiple locations
         if not path == input_path:
-            print('Grid file path in {nmlfile} ({gridpath}) does not match '
+            print('payu: error: '
+                  'Grid file path in {nmlfile} ({gridpath}) does not match '
                   'input path ({inputpath})'.format(
                     nmlfile=self.ice_nml_fname,
                     gridpath=path,
@@ -96,7 +97,8 @@ class Cice(Model):
             tmp_path, _ = os.path.split(self.ice_in[nml].get(var))
             tmp_path = os.path.normpath(tmp_path)
             if not path == tmp_path:
-                print('Paths for {var} ({varpath}) and grid_file '
+                print('payu: error: '
+                      'Paths for {var} ({varpath}) and grid_file '
                       '({gridpath}) in {nmlfile} do not '
                       'match'.format(var=var,
                                      varpath=tmp_path,

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -80,13 +80,6 @@ class Cice(Model):
             if input_dir is None:
                 input_path = path
 
-        # kmt must use the same directory path as grid_file
-        kmt_input_path, _ = os.path.split(grid_nml['kmt_file'])
-        if not path == kmt_input_path:
-            print('Paths for kmt_file and grid_file in {nmlfile} do not '
-                  'match'.format(nmlfile=self.ice_nml_fname))
-            sys.exit(1)
-
         # Check for consistency in input paths due to cice having the same
         # information in multiple locations
         if not path == input_path:
@@ -97,6 +90,15 @@ class Cice(Model):
                     inputpath=input_path
             ))
             sys.exit(1)
+
+        # Check paths are consistent in namelist
+        for var, nml in (('kmt_file', 'grid_nml'), ('pointer_file', 'setup_nml')):
+            tmp_path, _ = os.path.split(self.ice_in[nml].get(var))
+            tmp_path = os.path.normpath(tmp_path)
+            if not path == tmp_path:
+                print('Paths for {var} ({varpath}) and grid_file ({gridpath}) in {nmlfile} do not '
+                      'match'.format(var=var, varpath=tmp_path, gridpath=path, nmlfile=self.ice_nml_fname))
+                sys.exit(1)
             
         if not os.path.isabs(input_path):
             input_path = os.path.join(self.work_path, input_path)

--- a/payu/models/cice5.py
+++ b/payu/models/cice5.py
@@ -61,7 +61,7 @@ class Cice5(Cice):
     def set_model_pathnames(self):
         super(Cice5, self).set_model_pathnames()
 
-        self.split_paths = (not self.work_input_path == self.work_restart_path)
+        self.split_paths = (self.work_input_path != self.work_restart_path)
 
         if self.split_paths:
             self.copy_inputs = False
@@ -69,8 +69,8 @@ class Cice5(Cice):
     def archive(self):
         super(Cice5, self).archive()
 
-        res_ptr_path = os.path.join(self.restart_path, 'ice.restart_file')
         if not self.split_paths:
+            res_ptr_path = os.path.join(self.restart_path, 'ice.restart_file')
             with open(res_ptr_path) as f:
                 res_name = os.path.basename(f.read()).strip()
 
@@ -83,8 +83,7 @@ class Cice5(Cice):
                         continue
                     os.remove(os.path.join(self.restart_path, f))
         else:
-            os.remove(res_ptr_path)
-            
+            shutil.rmtree(self.work_input_path)
 
     def get_prior_restart_files(self):
         if self.prior_restart_path is not None:

--- a/payu/models/cice5.py
+++ b/payu/models/cice5.py
@@ -70,9 +70,6 @@ class Cice5(Cice):
         super(Cice5, self).archive()
 
         if not self.split_paths:
-            # If inputs and restarts are in the same directory have to delete old
-            # ice restarts 
-
             res_ptr_path = os.path.join(self.restart_path, 'ice.restart_file')
             with open(res_ptr_path) as f:
                 res_name = os.path.basename(f.read()).strip()

--- a/payu/models/cice5.py
+++ b/payu/models/cice5.py
@@ -11,6 +11,7 @@ http://www.apache.org/licenses/LICENSE-2.0
 from __future__ import print_function
 
 import os
+import shutil
 
 from payu.models.cice import Cice
 from payu.fsops import mkdir_p

--- a/payu/models/cice5.py
+++ b/payu/models/cice5.py
@@ -61,24 +61,30 @@ class Cice5(Cice):
     def set_model_pathnames(self):
         super(Cice5, self).set_model_pathnames()
 
-        # Change the INPUT path, we want everything to go into RESTART
-        self.work_input_path = self.work_restart_path
+        self.split_paths = (not self.work_input_path == self.work_restart_path)
+
+        if self.split_paths:
+            self.copy_inputs = False
 
     def archive(self):
         super(Cice5, self).archive()
 
-        res_ptr_path = os.path.join(self.restart_path, 'ice.restart_file')
-        with open(res_ptr_path) as f:
-            res_name = os.path.basename(f.read()).strip()
+        if not self.split_paths:
+            # If inputs and restarts are in the same directory have to delete old
+            # ice restarts 
 
-        assert os.path.exists(os.path.join(self.restart_path, res_name))
+            res_ptr_path = os.path.join(self.restart_path, 'ice.restart_file')
+            with open(res_ptr_path) as f:
+                res_name = os.path.basename(f.read()).strip()
 
-        # Delete the old restart file (keep the one in ice.restart_file)
-        for f in self.get_prior_restart_files():
-            if f.startswith('iced.'):
-                if f == res_name:
-                    continue
-                os.remove(os.path.join(self.restart_path, f))
+            assert os.path.exists(os.path.join(self.restart_path, res_name))
+
+            # Delete the old restart file (keep the one in ice.restart_file)
+            for f in self.get_prior_restart_files():
+                if f.startswith('iced.'):
+                    if f == res_name:
+                        continue
+                    os.remove(os.path.join(self.restart_path, f))
 
     def get_prior_restart_files(self):
         if self.prior_restart_path is not None:

--- a/payu/models/cice5.py
+++ b/payu/models/cice5.py
@@ -69,8 +69,8 @@ class Cice5(Cice):
     def archive(self):
         super(Cice5, self).archive()
 
+        res_ptr_path = os.path.join(self.restart_path, 'ice.restart_file')
         if not self.split_paths:
-            res_ptr_path = os.path.join(self.restart_path, 'ice.restart_file')
             with open(res_ptr_path) as f:
                 res_name = os.path.basename(f.read()).strip()
 
@@ -82,6 +82,9 @@ class Cice5(Cice):
                     if f == res_name:
                         continue
                     os.remove(os.path.join(self.restart_path, f))
+        else:
+            os.remove(res_ptr_path)
+            
 
     def get_prior_restart_files(self):
         if self.prior_restart_path is not None:

--- a/payu/runlog.py
+++ b/payu/runlog.py
@@ -55,6 +55,8 @@ class Runlog(object):
         config_path = os.path.join(self.expt.control_path,
                                    DEFAULT_CONFIG_FNAME)
 
+        self.manifest = []
+
         if os.path.isfile(config_path):
             self.manifest.append(config_path)
 


### PR DESCRIPTION
Added support for splitting input and restart directories in the `cice5` driver (actually mostly in the `cice` driver but there is no `cice4` version that supports this)

The `cice5` code change is here:

https://github.com/OceansAus/cice5/commit/465494bb551ec15ec3ec82308359e6c7d3ae28a5

This change tries to be backwards compatible. I have tested on an access-om2 1 degree model and it seems to work fine.

To use this you also need to make a couple of changes to the cice_in.nml file:

Must add this to `&setup_nml`
```
input_dir      = 'INPUT/'
```
and change all instances of paths with `RESTART` at the beginning, to `INPUT`
```
pointer_file   = 'INPUT/ice.restart_file'
grid_file    = 'INPUT/grid.nc'
kmt_file     = 'INPUT/kmt.nc'
```