### PR TITLE
Introduced bug in check_fast when fixing the previous fullpath bug.

### DIFF
--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -119,7 +119,8 @@ class PayuManifest(YaManifest):
                     filepaths=list(hashvals.keys()),
                     hashfn=full_hashes,
                     force=True,
-                    fullpaths=[self.fullpath(fpath) for fpath in self]
+                    fullpaths=[self.fullpath(fpath) for fpath 
+                               in list(hashvals.keys())]
                 )
 
                 # Flag need to update version on disk


### PR DESCRIPTION
Used all paths instead of just the paths of the changed files. Fixed