### PR TITLE
Altered UM restart calendar handling

### DIFF
--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -119,7 +119,7 @@ class PayuManifest(YaManifest):
                     filepaths=list(hashvals.keys()),
                     hashfn=full_hashes,
                     force=True,
-                    fullpaths=[self.fullpath(fpath) for fpath 
+                    fullpaths=[self.fullpath(fpath) for fpath
                                in list(hashvals.keys())]
                 )
 

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -218,7 +218,7 @@ class PayuManifest(YaManifest):
         """
         Used to make all links at once for reproduce runs or scaninputs=False
         """
-        for filepath in self:
+        for filepath in list(self):
             self.make_link(filepath)
 
     def copy(self, path):

--- a/payu/models/access.py
+++ b/payu/models/access.py
@@ -207,13 +207,13 @@ class Access(Model):
                     if os.path.exists(f_src):
                         shutil.move(f_src, f_dst)
 
-            # Copy configs from work path to restart
-            for f_name in model.config_files:
-                f_src = os.path.join(model.work_path, f_name)
-                f_dst = os.path.join(model.restart_path, f_name)
+                # Copy configs from work path to restart
+                for f_name in model.config_files:
+                    f_src = os.path.join(model.work_path, f_name)
+                    f_dst = os.path.join(model.restart_path, f_name)
 
-                if os.path.exists(f_src):
-                    shutil.copy2(f_src, f_dst)
+                    if os.path.exists(f_src):
+                        shutil.copy2(f_src, f_dst)
 
             if model.model_type == 'cice5':
                 cice5 = model

--- a/payu/models/access.py
+++ b/payu/models/access.py
@@ -193,6 +193,9 @@ class Access(Model):
         if not self.top_level_model:
             return
 
+        cice5 = None
+        mom = None
+
         for model in self.expt.models:
             if model.model_type == 'cice':
 
@@ -212,9 +215,6 @@ class Access(Model):
                 if os.path.exists(f_src):
                     shutil.copy2(f_src, f_dst)
 
-        cice5 = None
-        mom = None
-        for model in self.expt.models:
             if model.model_type == 'cice5':
                 cice5 = model
             elif model.model_type == 'mom':

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -287,11 +287,9 @@ class Model(object):
             for f_name in files:
                 f_path = os.path.join(path, f_name)
                 if os.path.islink(f_path) or os.path.getsize(f_path) == 0:
-                    print("Removing {file}".format(file=f_path))
                     os.remove(f_path)
             if len(os.listdir(path)) == 0:
                 os.rmdir(path)
-                print("Removing {dir}".format(dir=path))
 
     def collate(self):
         """Collate any tiled output into a single file."""

--- a/payu/models/oasis.py
+++ b/payu/models/oasis.py
@@ -32,7 +32,7 @@ class Oasis(Model):
 
         self.model_type = 'oasis'
         self.copy_restarts = True
-        self.copy_inputs = True
+        self.copy_inputs = False
 
         self.config_files = ['namcouple']
 
@@ -123,7 +123,7 @@ class Oasis(Model):
             f_dst = os.path.join(self.restart_path, f)
 
             if os.path.exists(f_src):
-                shutil.copy2(f_src, f_dst)
+                shutil.move(f_src, f_dst)
 
     def collate(self):
         pass

--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -19,6 +19,7 @@ import string
 
 # Extensions
 import f90nml
+import yaml
 
 # Local
 from payu.fsops import mkdir_p, make_symlink
@@ -33,6 +34,7 @@ class UnifiedModel(Model):
 
         self.model_type = 'um'
         self.default_exec = 'um'
+        self.restart_calendar_file = self.model_type + '.res.yaml'
 
         # TODO: many of these can probably be ignored.
         self.config_files = ['CNTLALL', 'prefix.CNTLATM', 'prefix.CNTLGEN',
@@ -50,6 +52,7 @@ class UnifiedModel(Model):
         super(UnifiedModel, self).set_model_pathnames()
 
         self.work_input_path = os.path.join(self.work_path, 'INPUT')
+        self.work_init_path = os.path.join(self.work_path, 'INIT')
 
     def archive(self):
         super(UnifiedModel, self).archive()
@@ -71,12 +74,22 @@ class UnifiedModel(Model):
 
         resubmit_inc = nml['NLSTCALL']['RUN_RESUBMIT_INC']
         runtime = um_time_to_time(resubmit_inc)
-        runtime = datetime.timedelta(seconds=runtime)
+        # runtime = datetime.timedelta(seconds=runtime)
 
         basis_time = nml['NLSTCALL']['MODEL_BASIS_TIME']
         init_date = um_date_to_date(basis_time)
 
-        end_date = date_to_um_dump_date(init_date + runtime)
+        end_date = cal.date_plus_seconds(init_date,
+                                         runtime,
+                                         cal.GREGORIAN)
+
+        # Save model time to restart next run
+        with open(os.path.join(self.restart_path, 
+                  self.restart_calendar_file), 'w') as restart_file:
+            restart_file.write(yaml.dump({'end_date':end_date}, 
+                               default_flow_style=False))
+
+        end_date = date_to_um_dump_date(end_date)
 
         restart_dump = os.path.join(self.work_path,
                                     'aiihca.da{0}'.format(end_date))
@@ -84,8 +97,8 @@ class UnifiedModel(Model):
         if os.path.exists(restart_dump):
             shutil.copy(restart_dump, f_dst)
         else:
-            print('payu: error: Model has not produced a restart dump file'
-                  '{} does not exist. '
+            print('payu: error: Model has not produced a restart dump file:\n'
+                  '{} does not exist.\n'
                   'Check DUMPFREQim in namelists'.format(restart_dump))
 
     def collate(self):
@@ -129,19 +142,13 @@ class UnifiedModel(Model):
         work_nml = f90nml.read(work_nml_path)
 
         # Modify namelists for a continuation run.
-        if self.prior_output_path and not self.expt.repeat_run:
+        if self.prior_restart_path and not self.expt.repeat_run:
 
-            prior_nml_path = os.path.join(self.prior_output_path, 'namelists')
-            prior_nml = f90nml.read(prior_nml_path)
+            with open(os.path.join(self.work_init_path, 
+                      self.restart_calendar_file), 'r') as restart_file:
+                restart_info = yaml.load(restart_file)
 
-            basis_time = prior_nml['NLSTCALL']['MODEL_BASIS_TIME']
-            init_date = um_date_to_date(basis_time)
-            resubmit_inc = prior_nml['NLSTCALL']['RUN_RESUBMIT_INC']
-            runtime = um_time_to_time(resubmit_inc)
-
-            run_start_date = cal.date_plus_seconds(init_date,
-                                                   runtime,
-                                                   cal.GREGORIAN)
+            run_start_date = restart_info['end_date']
 
             # Write out and save new calendar information.
             run_start_date_um = date_to_um_date(run_start_date)

--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -52,7 +52,6 @@ class UnifiedModel(Model):
         super(UnifiedModel, self).set_model_pathnames()
 
         self.work_input_path = os.path.join(self.work_path, 'INPUT')
-        self.work_init_path = os.path.join(self.work_path, 'INIT')
 
     def archive(self):
         super(UnifiedModel, self).archive()
@@ -141,11 +140,14 @@ class UnifiedModel(Model):
         work_nml_path = os.path.join(self.work_path, 'namelists')
         work_nml = f90nml.read(work_nml_path)
 
-        # Modify namelists for a continuation run.
-        if self.prior_restart_path and not self.expt.repeat_run:
+        restart_calendar_path = os.path.join(self.work_init_path, 
+                      self.restart_calendar_file)
 
-            with open(os.path.join(self.work_init_path, 
-                      self.restart_calendar_file), 'r') as restart_file:
+        # Modify namelists for a continuation run.
+        if self.prior_restart_path and not self.expt.repeat_run \
+            and os.path.exists(restart_calendar_path):
+
+            with open(restart_calendar_path, 'r') as restart_file:
                 restart_info = yaml.load(restart_file)
 
             run_start_date = restart_info['end_date']

--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -83,9 +83,9 @@ class UnifiedModel(Model):
                                          cal.GREGORIAN)
 
         # Save model time to restart next run
-        with open(os.path.join(self.restart_path, 
+        with open(os.path.join(self.restart_path,
                   self.restart_calendar_file), 'w') as restart_file:
-            restart_file.write(yaml.dump({'end_date':end_date}, 
+            restart_file.write(yaml.dump({'end_date': end_date},
                                default_flow_style=False))
 
         end_date = date_to_um_dump_date(end_date)
@@ -140,12 +140,12 @@ class UnifiedModel(Model):
         work_nml_path = os.path.join(self.work_path, 'namelists')
         work_nml = f90nml.read(work_nml_path)
 
-        restart_calendar_path = os.path.join(self.work_init_path, 
-                      self.restart_calendar_file)
+        restart_calendar_path = os.path.join(self.work_init_path,
+                                             self.restart_calendar_file)
 
         # Modify namelists for a continuation run.
         if self.prior_restart_path and not self.expt.repeat_run \
-            and os.path.exists(restart_calendar_path):
+           and os.path.exists(restart_calendar_path):
 
             with open(restart_calendar_path, 'r') as restart_file:
                 restart_info = yaml.load(restart_file)

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -19,7 +19,7 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path, reproduce):
 
     # Get job submission configuration
     pbs_config = fsops.read_config(config_path)
-    pbs_vars = cli.set_env_vars(init_run, n_runs, lab_path, 
+    pbs_vars = cli.set_env_vars(init_run, n_runs, lab_path,
                                 reproduce=reproduce)
 
     # Set the queue
@@ -136,8 +136,8 @@ def runscript():
         if n_runs_per_submit > 1 and subrun < n_runs_per_submit:
             expt.counter += 1
             expt.set_output_paths()
-            # Does not make sense to reproduce a multiple run. Take 
-            # care of this with argument processing?
+            # Does not make sense to reproduce a multiple run.
+            # Take care of this with argument processing?
             expt.reproduce = False
         else:
             break


### PR DESCRIPTION
Added explicit `um_calendar.res.yaml` file from which to restart the UM, rather than reading in prior version of `namelists`. This breaks a dependency on a prior output directory.

Fixes https://github.com/marshallward/payu/issues/168

`namcouple` is not required for model time restarts, so is not copied to restarts, but instead is archived in output.