### PR TITLE
Updated MITgcm calendar handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@ language: python
 python:
     - "2.7"
     - "3.5"
+    - "3.6"
 # Disabling Torque setup until we can get this working on Travis
 before_install:
     - sudo apt-get install torque-server torque-client torque-mom torque-pam
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then
-          sudo apt-get install libhdf5-serial-dev netcdf-bin libnetcdf-dev; fi
     - sudo ./test/setup_torque.sh
 install:
     - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
     - "2.7"
     - "3.5"
     - "3.6"
-    - "3.7"
 # Disabling Torque setup until we can get this working on Travis
 before_install:
     - sudo apt-get install torque-server torque-client torque-mom torque-pam

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
     - "2.7"
-    - "3.4"
     - "3.5"
 # Disabling Torque setup until we can get this working on Travis
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
     - "2.7"
     - "3.5"
     - "3.6"
+    - "3.7"
 # Disabling Torque setup until we can get this working on Travis
 before_install:
     - sudo apt-get install torque-server torque-client torque-mom torque-pam

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
     - "3.5"
 # Disabling Torque setup until we can get this working on Travis
 before_install:
-    - sudo apt-get install torque-server torque-client torque-mom torque-pam libnetcdf-dev netcdf-bin
+    - sudo apt-get install torque-server torque-client torque-mom torque-pam libnetcdf-dev libhdf5-dev
     - sudo ./test/setup_torque.sh
 install:
     - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ python:
     - "3.5"
 # Disabling Torque setup until we can get this working on Travis
 before_install:
-    - sudo apt-get install torque-server torque-client torque-mom torque-pam libnetcdf-dev libhdf5-dev
+    - sudo apt-get install torque-server torque-client torque-mom torque-pam
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then
+          sudo apt-get install libhdf5-serial-dev netcdf-bin libnetcdf-dev; fi
     - sudo ./test/setup_torque.sh
 install:
     - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
     - "3.5"
 # Disabling Torque setup until we can get this working on Travis
 before_install:
-    - sudo apt-get install torque-server torque-client torque-mom torque-pam
+    - sudo apt-get install torque-server torque-client torque-mom torque-pam libnetcdf-dev netcdf-bin
     - sudo ./test/setup_torque.sh
 install:
     - pip install .


### PR DESCRIPTION
Can change timestep within a run and maintain correct model time and step number.

Uses a yaml restart file to save the model end time for the current
run which is read in by the next run.